### PR TITLE
Add support for --retry option to automatically retry failed tasks (&& Update dependencies)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
-    "presets": ["power-assert"],
-    "plugins": ["transform-async-to-generator"],
-    "only": "/test/*.js",
-    "sourceMaps": "inline"
+  "presets": ["@babel/preset-env"],
+  "plugins": ["transform-async-to-generator"],
+  "only": ["/test/*.js"],
+  "sourceMaps": "inline"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-    "root": true,
-    "extends": ["mysticatea", "mysticatea/node"],
-    "rules": {
-        "prefer-rest-params": "off",
-        "prefer-spread": "off"
-    }
-}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 | index | [npm-run-all] | [run-s] | [run-p] | [Node API] |
-|-------|---------------|---------|---------|------------|
+| ----- | ------------- | ------- | ------- | ---------- |
 
 # npm-run-all
 
@@ -16,7 +16,7 @@ A CLI tool to run multiple npm-scripts in parallel or sequential.
 
 - **Simplify.** The official `npm run-script` command cannot run multiple scripts, so if we want to run multiple scripts, it's redundant a bit. Let's shorten it by glob-like patterns.<br>
   Before: `npm run clean && npm run build:css && npm run build:js && npm run build:html`<br>
-  After: `npm-run-all clean build:*`
+  After: `npm-run-all clean 'build:*'`
 - **Cross platform.** We sometimes use `&` to run multiple command in parallel, but `cmd.exe` (`npm run-script` uses it by default) does not support the `&`. Half of Node.js users are using it on Windows, so the use of `&` might block contributions. `npm-run-all --parallel` works well on Windows as well.
 
 ## 💿 Installation

--- a/bin/common/bootstrap.js
+++ b/bin/common/bootstrap.js
@@ -5,47 +5,54 @@
  */
 "use strict"
 
-//------------------------------------------------------------------------------
-// Public Interface
-//------------------------------------------------------------------------------
-/*eslint-disable no-process-exit */
+ 
 
 module.exports = function bootstrap(name) {
-    const argv = process.argv.slice(2)
+  const argv = process.argv.slice(2)
 
-    switch (argv[0]) {
-        case undefined:
-        case "-h":
-        case "--help":
-            return require(`../${name}/help`)(process.stdout)
+  switch (argv[0]) {
+    case undefined:
+    case "-h":
+    case "--help":
+      return require(`../${name}/help`)(process.stdout)
 
-        case "-v":
-        case "--version":
-            return require("./version")(process.stdout)
+    case "-v":
+    case "--version":
+      return require("./version")(process.stdout)
 
-        default:
-            // https://github.com/mysticatea/npm-run-all/issues/105
-            // Avoid MaxListenersExceededWarnings.
-            process.stdout.setMaxListeners(0)
-            process.stderr.setMaxListeners(0)
-            process.stdin.setMaxListeners(0)
+    default:
+      // Avoid MaxListenersExceededWarnings.
+      process.stdout.setMaxListeners(0)
+      process.stderr.setMaxListeners(0)
+      process.stdin.setMaxListeners(0)
 
-            // Main
-            return require(`../${name}/main`)(
-                argv,
-                process.stdout,
-                process.stderr
-            ).then(
-                () => {
-                    // I'm not sure why, but maybe the process never exits
-                    // on Git Bash (MINGW64)
-                    process.exit(0)
-                },
-                () => {
-                    process.exit(1)
-                }
-            )
-    }
+      // Supporto --retry <count>
+      const retryIndex = argv.findIndex((arg) => arg === "-r" || arg === "--retry")
+      let retryCount = 0
+      if (retryIndex !== -1) {
+        retryCount = parseInt(argv[retryIndex + 1], 10) || 0
+        argv.splice(retryIndex, 2)
+      }
+
+      // Supporto --summary
+      const summaryIndex = argv.findIndex((arg) => arg === "--summary")
+      let summaryFlag = false
+      if (summaryIndex !== -1) {
+        summaryFlag = true
+        argv.splice(summaryIndex, 1)
+      }
+
+      const options = { retry: retryCount, summary: summaryFlag }
+      return require(`../${name}/main`)(argv, process.stdout, process.stderr, options).then(
+        () => {
+          // On some platforms the process may not exit automatically.
+          process.exit(0)
+        },
+        () => {
+          process.exit(1)
+        }
+      )
+  }
 }
 
-/*eslint-enable */
+ 

--- a/bin/common/parse-cli-args.js
+++ b/bin/common/parse-cli-args.js
@@ -5,7 +5,7 @@
  */
 "use strict"
 
-/*eslint-disable no-process-env */
+ 
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -18,234 +18,194 @@ const CONCAT_OPTIONS = /^-[clnprs]+$/
 
 /**
  * Overwrites a specified package config.
- *
- * @param {object} config - A config object to be overwritten.
- * @param {string} packageName - A package name to overwrite.
- * @param {string} variable - A variable name to overwrite.
- * @param {string} value - A new value to overwrite.
- * @returns {void}
  */
 function overwriteConfig(config, packageName, variable, value) {
-    const scope = config[packageName] || (config[packageName] = {})
-    scope[variable] = value
+  const scope = config[packageName] || (config[packageName] = {})
+  scope[variable] = value
 }
 
 /**
- * Creates a package config object.
- * This checks `process.env` and creates the default value.
- *
- * @returns {object} Created config object.
+ * Creates packageConfig from env.
  */
 function createPackageConfig() {
-    const retv = {}
-    const packageName = process.env.npm_package_name
-    if (!packageName) {
-        return retv
+  const retv = {}
+  const pkgName = process.env.npm_package_name
+  if (!pkgName) return retv
+  for (const key of Object.keys(process.env)) {
+    const m = PACKAGE_CONFIG_PATTERN.exec(key)
+    if (m) {
+      overwriteConfig(retv, pkgName, m[1], process.env[key])
     }
-
-    for (const key of Object.keys(process.env)) {
-        const m = PACKAGE_CONFIG_PATTERN.exec(key)
-        if (m != null) {
-            overwriteConfig(retv, packageName, m[1], process.env[key])
-        }
-    }
-
-    return retv
+  }
+  return retv
 }
 
 /**
- * Adds a new group into a given list.
- *
- * @param {object[]} groups - A group list to add.
- * @param {object} initialValues - A key-value map for the default of new value.
- * @returns {void}
+ * Adds a new group into `groups`.
  */
 function addGroup(groups, initialValues) {
-    groups.push(Object.assign(
-        { parallel: false, patterns: [] },
-        initialValues || {}
-    ))
+  groups.push(Object.assign({ parallel: false, patterns: [] }, initialValues || {}))
 }
 
 /**
- * ArgumentSet is values of parsed CLI arguments.
- * This class provides the getter to get the last group.
+ * Holds parsed CLI arguments.
  */
 class ArgumentSet {
-    /**
-     * @param {object} initialValues - A key-value map for the default of new value.
-     * @param {object} options - A key-value map for the options.
-     */
-    constructor(initialValues, options) {
-        this.config = {}
-        this.continueOnError = false
-        this.groups = []
-        this.maxParallel = 0
-        this.npmPath = null
-        this.packageConfig = createPackageConfig()
-        this.printLabel = false
-        this.printName = false
-        this.race = false
-        this.rest = []
-        this.silent = process.env.npm_config_loglevel === "silent"
-        this.singleMode = Boolean(options && options.singleMode)
+  constructor(initialValues, options) {
+    this.config = {}
+    this.continueOnError = false
+    this.groups = []
+    this.maxParallel = 0
+    this.npmPath = null
+    this.packageConfig = createPackageConfig()
+    this.printLabel = false
+    this.printName = false
+    this.race = false
+    this.rest = []
+    this.silent = process.env.npm_config_loglevel === "silent"
+    this.singleMode = Boolean(options && options.singleMode)
+    this.retry = (initialValues && initialValues.retry) || 0
+    this.summary = (initialValues && initialValues.summary) || false
 
-        addGroup(this.groups, initialValues)
-    }
+    addGroup(this.groups, initialValues)
+  }
 
-    /**
-     * Gets the last group.
-     */
-    get lastGroup() {
-        return this.groups[this.groups.length - 1]
-    }
+  get lastGroup() {
+    return this.groups[this.groups.length - 1]
+  }
 
-    /**
-     * Gets "parallel" flag.
-     */
-    get parallel() {
-        return this.groups.some(g => g.parallel)
-    }
+  get parallel() {
+    return this.groups.some((g) => g.parallel)
+  }
 }
 
-/**
- * Parses CLI arguments.
- *
- * @param {ArgumentSet} set - The parsed CLI arguments.
- * @param {string[]} args - CLI arguments.
- * @returns {ArgumentSet} set itself.
- */
-function parseCLIArgsCore(set, args) {    // eslint-disable-line complexity
-    LOOP:
-    for (let i = 0; i < args.length; ++i) {
-        const arg = args[i]
+function parseCLIArgsCore(set, args) {
+  LOOP: for (let i = 0; i < args.length; ++i) {
+    const arg = args[i]
+    switch (arg) {
+      case "--":
+        set.rest = args.slice(i + 1)
+        break LOOP
 
-        switch (arg) {
-            case "--":
-                set.rest = args.slice(1 + i)
-                break LOOP
+      case "--color":
+      case "--no-color":
+        break
 
-            case "--color":
-            case "--no-color":
-                // do nothing.
-                break
+      case "-c":
+      case "--continue-on-error":
+        set.continueOnError = true
+        break
 
-            case "-c":
-            case "--continue-on-error":
-                set.continueOnError = true
-                break
+      case "-l":
+      case "--print-label":
+        set.printLabel = true
+        break
 
-            case "-l":
-            case "--print-label":
-                set.printLabel = true
-                break
+      case "-n":
+      case "--print-name":
+        set.printName = true
+        break
 
-            case "-n":
-            case "--print-name":
-                set.printName = true
-                break
+      case "-r":
+      case "--race":
+        set.race = true
+        break
 
-            case "-r":
-            case "--race":
-                set.race = true
-                break
+      case "--retry":
+        set.retry = Number(args[++i]) || 0
+        break
 
-            case "--silent":
-                set.silent = true
-                break
+      case "--summary":
+        set.summary = true
+        break
 
-            case "--max-parallel":
-                set.maxParallel = parseInt(args[++i], 10)
-                if (!Number.isFinite(set.maxParallel) || set.maxParallel <= 0) {
-                    throw new Error(`Invalid Option: --max-parallel ${args[i]}`)
-                }
-                break
+      case "--silent":
+        set.silent = true
+        break
 
-            case "-s":
-            case "--sequential":
-            case "--serial":
-                if (set.singleMode && arg === "-s") {
-                    set.silent = true
-                    break
-                }
-                if (set.singleMode) {
-                    throw new Error(`Invalid Option: ${arg}`)
-                }
-                addGroup(set.groups)
-                break
-
-            case "--aggregate-output":
-                set.aggregateOutput = true
-                break
-
-            case "-p":
-            case "--parallel":
-                if (set.singleMode) {
-                    throw new Error(`Invalid Option: ${arg}`)
-                }
-                addGroup(set.groups, { parallel: true })
-                break
-
-            case "--npm-path":
-                set.npmPath = args[++i] || null
-                break
-
-            default: {
-                let matched = null
-                if ((matched = OVERWRITE_OPTION.exec(arg))) {
-                    overwriteConfig(
-                        set.packageConfig,
-                        matched[1],
-                        matched[2],
-                        matched[3] || args[++i]
-                    )
-                }
-                else if ((matched = CONFIG_OPTION.exec(arg))) {
-                    set.config[matched[1]] = matched[2]
-                }
-                else if (CONCAT_OPTIONS.test(arg)) {
-                    parseCLIArgsCore(
-                        set,
-                        arg.slice(1).split("").map(c => `-${c}`)
-                    )
-                }
-                else if (arg[0] === "-") {
-                    throw new Error(`Invalid Option: ${arg}`)
-                }
-                else {
-                    set.lastGroup.patterns.push(arg)
-                }
-
-                break
-            }
+      case "--max-parallel":
+        set.maxParallel = parseInt(args[++i], 10)
+        if (!Number.isFinite(set.maxParallel) || set.maxParallel <= 0) {
+          throw new Error(`Invalid Option: --max-parallel ${args[i]}`)
         }
-    }
+        break
 
-    if (!set.parallel && set.aggregateOutput) {
-        throw new Error("Invalid Option: --aggregate-output (without parallel)")
-    }
-    if (!set.parallel && set.race) {
-        const race = args.indexOf("--race") !== -1 ? "--race" : "-r"
-        throw new Error(`Invalid Option: ${race} (without parallel)`)
-    }
-    if (!set.parallel && set.maxParallel !== 0) {
-        throw new Error("Invalid Option: --max-parallel (without parallel)")
-    }
+      case "-s":
+      case "--sequential":
+      case "--serial":
+        if (set.singleMode && arg === "-s") {
+          set.silent = true
+          break
+        }
+        if (set.singleMode) {
+          throw new Error(`Invalid Option: ${arg}`)
+        }
+        addGroup(set.groups)
+        break
 
-    return set
+      case "--aggregate-output":
+        set.aggregateOutput = true
+        break
+
+      case "-p":
+      case "--parallel":
+        if (set.singleMode) {
+          throw new Error(`Invalid Option: ${arg}`)
+        }
+        addGroup(set.groups, { parallel: true })
+        break
+
+      case "--npm-path":
+        set.npmPath = args[++i] || null
+        break
+
+      default: {
+        let m = null
+        if ((m = OVERWRITE_OPTION.exec(arg))) {
+          overwriteConfig(set.packageConfig, m[1], m[2], m[3] || args[++i])
+        } else if ((m = CONFIG_OPTION.exec(arg))) {
+          set.config[m[1]] = m[2]
+        } else if (CONCAT_OPTIONS.test(arg)) {
+          parseCLIArgsCore(
+            set,
+            arg
+              .slice(1)
+              .split("")
+              .map((c) => `-${c}`)
+          )
+        } else if (arg[0] === "-") {
+          throw new Error(`Invalid Option: ${arg}`)
+        } else {
+          set.lastGroup.patterns.push(arg)
+        }
+      }
+    }
+  }
+
+  if (!set.parallel && set.aggregateOutput) {
+    throw new Error("Invalid Option: --aggregate-output (without parallel)")
+  }
+  if (!set.parallel && set.race) {
+    const flag = args.includes("--race") ? "--race" : "-r"
+    throw new Error(`Invalid Option: ${flag} (without parallel)`)
+  }
+  if (!set.parallel && set.maxParallel !== 0) {
+    throw new Error("Invalid Option: --max-parallel (without parallel)")
+  }
+
+  return set
 }
 
 /**
  * Parses CLI arguments.
  *
- * @param {string[]} args - CLI arguments.
- * @param {object} initialValues - A key-value map for the default of new value.
- * @param {object} options - A key-value map for the options.
- * @param {boolean} options.singleMode - The flag to be single group mode.
- * @returns {ArgumentSet} The parsed CLI arguments.
+ * @param {string[]} args
+ * @param {object} initialValues
+ * @param {object} options
+ * @returns {ArgumentSet}
  */
 module.exports = function parseCLIArgs(args, initialValues, options) {
-    return parseCLIArgsCore(new ArgumentSet(initialValues, options), args)
+  return parseCLIArgsCore(new ArgumentSet(initialValues, options), args)
 }
 
-/*eslint-enable */
+ 

--- a/bin/npm-run-all/help.js
+++ b/bin/npm-run-all/help.js
@@ -17,7 +17,7 @@
  * @private
  */
 module.exports = function printHelp(output) {
-    output.write(`
+  output.write(`
 Usage:
     $ npm-run-all [--help | -h | --version | -v]
     $ npm-run-all [tasks] [OPTIONS]
@@ -58,14 +58,14 @@ Options:
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
 
 Examples:
-    $ npm-run-all --serial clean lint build:**
-    $ npm-run-all --parallel watch:**
-    $ npm-run-all clean lint --parallel "build:** -- --watch"
+    $ npm-run-all --serial clean lint 'build:*'*
+    $ npm-run-all --parallel 'watch:*'*
+    $ npm-run-all clean lint --parallel "'build:*'* -- --watch"
     $ npm-run-all -l -p start-server start-browser start-electron
 
 See Also:
     https://github.com/mysticatea/npm-run-all#readme
 `)
 
-    return Promise.resolve(null)
+  return Promise.resolve(null)
 }

--- a/bin/run-p/help.js
+++ b/bin/run-p/help.js
@@ -17,7 +17,7 @@
  * @private
  */
 module.exports = function printHelp(output) {
-    output.write(`
+  output.write(`
 Usage:
     $ run-p [--help | -h | --version | -v]
     $ run-p [OPTIONS] <tasks>
@@ -53,14 +53,14 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-p watch:**
-    $ run-p --print-label "build:** -- --watch"
-    $ run-p -sl "build:** -- --watch"
+    $ run-p 'watch:*'*
+    $ run-p --print-label "'build:*'* -- --watch"
+    $ run-p -sl "'build:*'* -- --watch"
     $ run-p start-server start-browser start-electron
 
 See Also:
     https://github.com/mysticatea/npm-run-all#readme
 `)
 
-    return Promise.resolve(null)
+  return Promise.resolve(null)
 }

--- a/bin/run-p/main.js
+++ b/bin/run-p/main.js
@@ -26,49 +26,46 @@ const parseCLIArgs = require("../common/parse-cli-args")
  * @private
  */
 module.exports = function npmRunAll(args, stdout, stderr) {
-    try {
-        const stdin = process.stdin
-        const argv = parseCLIArgs(args, { parallel: true }, { singleMode: true })
-        const group = argv.lastGroup
+  try {
+    const stdin = process.stdin
+    const argv = parseCLIArgs(args, { parallel: true }, { singleMode: true })
+    const group = argv.lastGroup
 
-        if (group.patterns.length === 0) {
-            return Promise.resolve(null)
-        }
-
-        const promise = runAll(
-            group.patterns,
-            {
-                stdout,
-                stderr,
-                stdin,
-                parallel: group.parallel,
-                maxParallel: argv.maxParallel,
-                continueOnError: argv.continueOnError,
-                printLabel: argv.printLabel,
-                printName: argv.printName,
-                config: argv.config,
-                packageConfig: argv.packageConfig,
-                silent: argv.silent,
-                arguments: argv.rest,
-                race: argv.race,
-                npmPath: argv.npmPath,
-                aggregateOutput: argv.aggregateOutput,
-            }
-        )
-
-        if (!argv.silent) {
-            promise.catch(err => {
-                //eslint-disable-next-line no-console
-                console.error("ERROR:", err.message)
-            })
-        }
-
-        return promise
+    if (group.patterns.length === 0) {
+      return Promise.resolve(null)
     }
-    catch (err) {
-        //eslint-disable-next-line no-console
-        console.error("ERROR:", err.message)
 
-        return Promise.reject(err)
+    const promise = runAll(group.patterns, {
+      stdout,
+      stderr,
+      stdin,
+      parallel: group.parallel,
+      maxParallel: argv.maxParallel,
+      continueOnError: argv.continueOnError,
+      printLabel: argv.printLabel,
+      printName: argv.printName,
+      config: argv.config,
+      packageConfig: argv.packageConfig,
+      silent: argv.silent,
+      arguments: argv.rest,
+      race: argv.race,
+      npmPath: argv.npmPath,
+      aggregateOutput: group.parallel && argv.aggregateOutput,
+      retry: argv.retry
+    })
+
+    if (!argv.silent) {
+      promise.catch((err) => {
+         
+        console.error("\nERROR:", err.message)
+      })
     }
+
+    return promise
+  } catch (err) {
+     
+    console.error("\nERROR:", err.message)
+
+    return Promise.reject(err)
+  }
 }

--- a/bin/run-s/help.js
+++ b/bin/run-s/help.js
@@ -17,7 +17,7 @@
  * @private
  */
 module.exports = function printHelp(output) {
-    output.write(`
+  output.write(`
 Usage:
     $ run-s [--help | -h | --version | -v]
     $ run-s [OPTIONS] <tasks>
@@ -47,14 +47,14 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-s build:**
-    $ run-s lint clean build:**
-    $ run-s --silent --print-name lint clean build:**
-    $ run-s -sn lint clean build:**
+    $ run-s 'build:*'*
+    $ run-s lint clean 'build:*'*
+    $ run-s --silent --print-name lint clean 'build:*'*
+    $ run-s -sn lint clean 'build:*'*
 
 See Also:
     https://github.com/mysticatea/npm-run-all#readme
 `)
 
-    return Promise.resolve(null)
+  return Promise.resolve(null)
 }

--- a/bin/run-s/main.js
+++ b/bin/run-s/main.js
@@ -26,46 +26,43 @@ const parseCLIArgs = require("../common/parse-cli-args")
  * @private
  */
 module.exports = function npmRunAll(args, stdout, stderr) {
-    try {
-        const stdin = process.stdin
-        const argv = parseCLIArgs(args, { parallel: false }, { singleMode: true })
-        const group = argv.lastGroup
+  try {
+    const stdin = process.stdin
+    const argv = parseCLIArgs(args, { parallel: false }, { singleMode: true })
+    const group = argv.lastGroup
 
-        if (group.patterns.length === 0) {
-            return Promise.resolve(null)
-        }
-
-        const promise = runAll(
-            group.patterns,
-            {
-                stdout,
-                stderr,
-                stdin,
-                parallel: group.parallel,
-                continueOnError: argv.continueOnError,
-                printLabel: argv.printLabel,
-                printName: argv.printName,
-                config: argv.config,
-                packageConfig: argv.packageConfig,
-                silent: argv.silent,
-                arguments: argv.rest,
-                npmPath: argv.npmPath,
-            }
-        )
-
-        if (!argv.silent) {
-            promise.catch(err => {
-                //eslint-disable-next-line no-console
-                console.error("ERROR:", err.message)
-            })
-        }
-
-        return promise
+    if (group.patterns.length === 0) {
+      return Promise.resolve(null)
     }
-    catch (err) {
-        //eslint-disable-next-line no-console
-        console.error("ERROR:", err.message)
 
-        return Promise.reject(err)
+    const promise = runAll(group.patterns, {
+      stdout,
+      stderr,
+      stdin,
+      parallel: group.parallel,
+      continueOnError: argv.continueOnError,
+      printLabel: argv.printLabel,
+      printName: argv.printName,
+      config: argv.config,
+      packageConfig: argv.packageConfig,
+      silent: argv.silent,
+      arguments: argv.rest,
+      npmPath: argv.npmPath,
+      retry: argv.retry
+    })
+
+    if (!argv.silent) {
+      promise.catch((err) => {
+         
+        console.error("\nERROR:", err.message)
+      })
     }
+
+    return promise
+  } catch (err) {
+     
+    console.error("\nERROR:", err.message)
+
+    return Promise.reject(err)
+  }
 }

--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -1,28 +1,28 @@
 | [index](../README.md) | [npm-run-all](npm-run-all.md) | [run-s](run-s.md) | [run-p](run-p.md) | Node API |
-|-----------------------|-------------------------------|-------------------|-------------------|----------|
+| --------------------- | ----------------------------- | ----------------- | ----------------- | -------- |
 
 # Node API
 
 A Node module to run given npm-scripts in parallel or sequential.
 
 ```js
-const runAll = require("npm-run-all");
+const runAll = require("npm-run-all")
 
-runAll(["clean", "lint", "build:*"], {parallel: false})
-    .then(() => {
-        console.log("done!");
-    })
-    .catch(err => {
-        console.log("failed!");
-    });
+runAll(["clean", "lint", "'build:*'"], { parallel: false })
+  .then(() => {
+    console.log("done!")
+  })
+  .catch((err) => {
+    console.log("failed!")
+  })
 
-runAll(["build:* -- --watch"], {parallel: true})
-    .then(() => {
-        console.log("done!");
-    })
-    .catch(err => {
-        console.log("failed!");
-    });
+runAll(["'build:*' -- --watch"], { parallel: true })
+  .then(() => {
+    console.log("done!")
+  })
+  .catch((err) => {
+    console.log("failed!")
+  })
 ```
 
 ## runAll
@@ -93,8 +93,8 @@ Run npm-scripts.
     If this is `null`, it reads from `package.json` in the current directory.
     Default is `null`.
 
-`runAll` returns a promise that will becomes *fulfilled* when all scripts are completed.
-The promise will become *rejected* when any of the scripts exit with a non-zero code.
+`runAll` returns a promise that will becomes _fulfilled_ when all scripts are completed.
+The promise will become _rejected_ when any of the scripts exit with a non-zero code.
 
 The promise gives `results` to the fulfilled handler.
 `results` is an array of objects which have 2 properties: `name` and `code`.
@@ -102,12 +102,11 @@ The `name` property is the name of a npm-script.
 The `code` property is the exit code of the npm-script. If the npm-script was not executed, the `code` property is `undefined`.
 
 ```js
-runAll(["clean", "lint", "build"])
-    .then(results => {
-        console.log(`${results[0].name}: ${results[0].code}`); // clean: 0
-        console.log(`${results[1].name}: ${results[1].code}`); // lint: 0
-        console.log(`${results[2].name}: ${results[2].code}`); // build: 0
-    });
+runAll(["clean", "lint", "build"]).then((results) => {
+  console.log(`${results[0].name}: ${results[0].code}`) // clean: 0
+  console.log(`${results[1].name}: ${results[1].code}`) // lint: 0
+  console.log(`${results[2].name}: ${results[2].code}`) // build: 0
+})
 ```
 
 ## About MaxListenersExceededWarning

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -1,5 +1,5 @@
 | [index](../README.md) | npm-run-all | [run-s](run-s.md) | [run-p](run-p.md) | [Node API](node-api.md) |
-|-----------------------|-------------|-------------------|-------------------|-------------------------|
+| --------------------- | ----------- | ----------------- | ----------------- | ----------------------- |
 
 # `npm-run-all` command
 
@@ -44,9 +44,9 @@ Options:
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
 
 Examples:
-    $ npm-run-all --serial clean lint build:**
-    $ npm-run-all --parallel watch:**
-    $ npm-run-all clean lint --parallel "build:** -- --watch"
+    $ npm-run-all --serial clean lint 'build:*'*
+    $ npm-run-all --parallel 'watch:*'*
+    $ npm-run-all clean lint --parallel "'build:*'* -- --watch"
     $ npm-run-all -l -p start-server start-browser start-electron
 ```
 
@@ -57,11 +57,11 @@ For example:
 
 ```json
 {
-    "scripts": {
-        "clean": "rimraf dist",
-        "lint":  "eslint src",
-        "build": "babel src -o lib"
-    }
+  "scripts": {
+    "clean": "rimraf dist",
+    "lint": "eslint src",
+    "build": "babel src -o lib"
+  }
 }
 ```
 
@@ -104,6 +104,7 @@ $ npm-run-all clean lint --parallel watch:html watch:js
 ```
 $ npm-run-all a b --parallel c d --sequential e f --parallel g h i
 ```
+
 or
 
 ```
@@ -121,14 +122,14 @@ We can use [glob]-like patterns to specify npm-scripts.
 The difference is one -- the separator is `:` instead of `/`.
 
 ```
-$ npm-run-all --parallel watch:*
+$ npm-run-all --parallel 'watch:*'
 ```
 
 In this case, runs sub scripts of `watch`. For example: `watch:html`, `watch:js`.
 But, doesn't run sub-sub scripts. For example: `watch:js:index`.
 
 ```
-$ npm-run-all --parallel watch:**
+$ npm-run-all --parallel 'watch:*'*
 ```
 
 If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
@@ -141,7 +142,7 @@ We can enclose a script name or a pattern in quotes to use arguments.
 The following 2 commands are similar.
 
 ```
-$ npm-run-all --parallel "build:* -- --watch"
+$ npm-run-all --parallel "'build:*' -- --watch"
 $ npm run build:aaa -- --watch & npm run build:bbb -- --watch
 ```
 
@@ -159,9 +160,9 @@ This is useful to pass through arguments from `npm run` command.
 
 ```json
 {
-    "scripts": {
-        "start": "npm-run-all build \"start-server -- --port {1}\" --"
-    }
+  "scripts": {
+    "start": "npm-run-all build \"start-server -- --port {1}\" --"
+  }
 }
 ```
 

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -1,5 +1,5 @@
 | [index](../README.md) | [npm-run-all](npm-run-all.md) | [run-s](run-s.md) | run-p | [Node API](node-api.md) |
-|-----------------------|-------------------------------|-------------------|-------|-------------------------|
+| --------------------- | ----------------------------- | ----------------- | ----- | ----------------------- |
 
 # `run-p` command
 
@@ -42,9 +42,9 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-p watch:**
-    $ run-p --print-label "build:** -- --watch"
-    $ run-p -l "build:** -- --watch"
+    $ run-p 'watch:*'*
+    $ run-p --print-label "'build:*'* -- --watch"
+    $ run-p -l "'build:*'* -- --watch"
     $ run-p start-server start-browser start-electron
 ```
 
@@ -55,11 +55,11 @@ For example:
 
 ```json
 {
-    "scripts": {
-        "clean": "rimraf dist",
-        "lint":  "eslint src",
-        "build": "babel src -o lib"
-    }
+  "scripts": {
+    "clean": "rimraf dist",
+    "lint": "eslint src",
+    "build": "babel src -o lib"
+  }
 }
 ```
 
@@ -85,14 +85,14 @@ We can use [glob]-like patterns to specify npm-scripts.
 The difference is one -- the separator is `:` instead of `/`.
 
 ```
-$ run-p watch:*
+$ run-p 'watch:*'
 ```
 
 In this case, runs sub scripts of `watch`. For example: `watch:html`, `watch:js`.
 But, doesn't run sub-sub scripts. For example: `watch:js:index`.
 
 ```
-$ run-p watch:**
+$ run-p 'watch:*'*
 ```
 
 If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
@@ -105,7 +105,7 @@ We can enclose a script name or a pattern in quotes to use arguments.
 The following 2 commands are similar.
 
 ```
-$ run-p "build:* -- --watch"
+$ run-p "'build:*' -- --watch"
 $ npm run build:aaa -- --watch & npm run build:bbb -- --watch
 ```
 
@@ -123,9 +123,9 @@ This is useful to pass through arguments from `npm run` command.
 
 ```json
 {
-    "scripts": {
-        "start": "run-p \"start-server -- --port {1}\" --"
-    }
+  "scripts": {
+    "start": "run-p \"start-server -- --port {1}\" --"
+  }
 }
 ```
 

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -1,5 +1,5 @@
 | [index](../README.md) | [npm-run-all](npm-run-all.md) | run-s | [run-p](run-p.md) | [Node API](node-api.md) |
-|-----------------------|-------------------------------|-------|-------------------|-------------------------|
+| --------------------- | ----------------------------- | ----- | ----------------- | ----------------------- |
 
 # `run-s` command
 
@@ -36,10 +36,10 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-s build:**
-    $ run-s lint clean build:**
-    $ run-s --silent --print-name lint clean build:**
-    $ run-s -sn lint clean build:**
+    $ run-s 'build:*'*
+    $ run-s lint clean 'build:*'*
+    $ run-s --silent --print-name lint clean 'build:*'*
+    $ run-s -sn lint clean 'build:*'*
 ```
 
 ### npm-scripts
@@ -49,11 +49,11 @@ For example:
 
 ```json
 {
-    "scripts": {
-        "clean": "rimraf dist",
-        "lint":  "eslint src",
-        "build": "babel src -o lib"
-    }
+  "scripts": {
+    "clean": "rimraf dist",
+    "lint": "eslint src",
+    "build": "babel src -o lib"
+  }
 }
 ```
 
@@ -76,14 +76,14 @@ We can use [glob]-like patterns to specify npm-scripts.
 The difference is one -- the separator is `:` instead of `/`.
 
 ```
-$ run-s build:*
+$ run-s 'build:*'
 ```
 
 In this case, runs sub scripts of `build`. For example: `build:html`, `build:js`.
 But, doesn't run sub-sub scripts. For example: `build:js:index`.
 
 ```
-$ run-s build:**
+$ run-s 'build:*'*
 ```
 
 If we use a globstar `**`, runs both sub scripts and sub-sub scripts.
@@ -114,9 +114,9 @@ This is useful to pass through arguments from `npm run` command.
 
 ```json
 {
-    "scripts": {
-        "start": "run-s build \"start-server -- --port {1}\" --"
-    }
+  "scripts": {
+    "start": "run-s build \"start-server -- --port {1}\" --"
+  }
 }
 ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,7 @@
+// .eslintrc.js
+module.exports = {
+  rules: {
+    "prefer-rest-params": "off",
+    "prefer-spread": "off"
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ const shellQuote = require("shell-quote")
 const matchTasks = require("./match-tasks")
 const readPackageJson = require("./read-package-json")
 const runTasks = require("./run-tasks")
+const { Writable } = require("stream") // added to create null streams
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -21,128 +22,81 @@ const runTasks = require("./run-tasks")
 
 const ARGS_PATTERN = /\{(!)?([*@]|\d+)([^}]+)?}/g
 
-/**
- * Converts a given value to an array.
- *
- * @param {string|string[]|null|undefined} x - A value to convert.
- * @returns {string[]} An array.
- */
+// New helper to create a no-op stream.
+function createNullStream() {
+  return new Writable({
+    write(chunk, encoding, callback) {
+      callback()
+    }
+  })
+}
+
 function toArray(x) {
-    if (x == null) {
-        return []
-    }
-    return Array.isArray(x) ? x : [x]
+  if (x == null) {
+    return []
+  }
+  return Array.isArray(x) ? x : [x]
 }
 
-/**
- * Replaces argument placeholders (such as `{1}`) by arguments.
- *
- * @param {string[]} patterns - Patterns to replace.
- * @param {string[]} args - Arguments to replace.
- * @returns {string[]} replaced
- */
 function applyArguments(patterns, args) {
-    const defaults = Object.create(null)
-
-    return patterns.map(pattern => pattern.replace(ARGS_PATTERN, (whole, indirectionMark, id, options) => {
-        if (indirectionMark != null) {
-            throw Error(`Invalid Placeholder: ${whole}`)
+  const defaults = Object.create(null)
+  return patterns.map((pattern) =>
+    pattern.replace(ARGS_PATTERN, (whole, indirectionMark, id, options) => {
+      if (indirectionMark != null) {
+        throw new Error(`Invalid Placeholder: ${whole}`)
+      }
+      if (id === "@") {
+        return shellQuote.quote(args)
+      }
+      if (id === "*") {
+        return shellQuote.quote([args.join(" ")])
+      }
+      const position = parseInt(id, 10)
+      if (position >= 1 && position <= args.length) {
+        return shellQuote.quote([args[position - 1]])
+      }
+      if (options != null) {
+        const prefix = options.slice(0, 2)
+        if (prefix === ":=") {
+          defaults[id] = shellQuote.quote([options.slice(2)])
+          return defaults[id]
         }
-        if (id === "@") {
-            return shellQuote.quote(args)
+        if (prefix === ":-") {
+          return shellQuote.quote([options.slice(2)])
         }
-        if (id === "*") {
-            return shellQuote.quote([args.join(" ")])
-        }
-
-        const position = parseInt(id, 10)
-        if (position >= 1 && position <= args.length) {
-            return shellQuote.quote([args[position - 1]])
-        }
-
-        // Address default values
-        if (options != null) {
-            const prefix = options.slice(0, 2)
-
-            if (prefix === ":=") {
-                defaults[id] = shellQuote.quote([options.slice(2)])
-                return defaults[id]
-            }
-            if (prefix === ":-") {
-                return shellQuote.quote([options.slice(2)])
-            }
-
-            throw Error(`Invalid Placeholder: ${whole}`)
-        }
-        if (defaults[id] != null) {
-            return defaults[id]
-        }
-
-        return ""
-    }))
+        throw new Error(`Invalid Placeholder: ${whole}`)
+      }
+      if (defaults[id] != null) {
+        return defaults[id]
+      }
+      return ""
+    })
+  )
 }
 
-/**
- * Parse patterns.
- * In parsing process, it replaces argument placeholders (such as `{1}`) by arguments.
- *
- * @param {string|string[]} patternOrPatterns - Patterns to run.
- *      A pattern is a npm-script name or a Glob-like pattern.
- * @param {string[]} args - Arguments to replace placeholders.
- * @returns {string[]} Parsed patterns.
- */
 function parsePatterns(patternOrPatterns, args) {
-    const patterns = toArray(patternOrPatterns)
-    const hasPlaceholder = patterns.some(pattern => ARGS_PATTERN.test(pattern))
-
-    return hasPlaceholder ? applyArguments(patterns, args) : patterns
+  const patterns = toArray(patternOrPatterns)
+  const hasPlaceholder = patterns.some((pattern) => ARGS_PATTERN.test(pattern))
+  return hasPlaceholder ? applyArguments(patterns, args) : patterns
 }
 
-/**
- * Converts a given config object to an `--:=` style option array.
- *
- * @param {object|null} config -
- *   A map-like object to overwrite package configs.
- *   Keys are package names.
- *   Every value is a map-like object (Pairs of variable name and value).
- * @returns {string[]} `--:=` style options.
- */
 function toOverwriteOptions(config) {
-    const options = []
-
-    for (const packageName of Object.keys(config)) {
-        const packageConfig = config[packageName]
-
-        for (const variableName of Object.keys(packageConfig)) {
-            const value = packageConfig[variableName]
-
-            options.push(`--${packageName}:${variableName}=${value}`)
-        }
+  const opts = []
+  for (const pkg of Object.keys(config)) {
+    const pkgCfg = config[pkg]
+    for (const varName of Object.keys(pkgCfg)) {
+      opts.push(`--${pkg}:${varName}=${pkgCfg[varName]}`)
     }
-
-    return options
+  }
+  return opts
 }
 
-/**
- * Converts a given config object to an `--a=b` style option array.
- *
- * @param {object|null} config -
- *   A map-like object to set configs.
- * @returns {string[]} `--a=b` style options.
- */
 function toConfigOptions(config) {
-    return Object.keys(config).map(key => `--${key}=${config[key]}`)
+  return Object.keys(config).map((key) => `--${key}=${config[key]}`)
 }
 
-/**
- * Gets the maximum length.
- *
- * @param {number} length - The current maximum length.
- * @param {string} name - A name.
- * @returns {number} The maximum length.
- */
 function maxLength(length, name) {
-    return Math.max(name.length, length)
+  return Math.max(name.length, length)
 }
 
 //------------------------------------------------------------------------------
@@ -150,138 +104,106 @@ function maxLength(length, name) {
 //------------------------------------------------------------------------------
 
 /**
- * Runs npm-scripts which are matched with given patterns.
+ * Runs npm-scripts matched by patterns, with retry and optional summary.
  *
  * @param {string|string[]} patternOrPatterns - Patterns to run.
- *   A pattern is a npm-script name or a Glob-like pattern.
- * @param {object|undefined} [options] Optional.
- * @param {boolean} options.parallel -
- *   If this is `true`, run scripts in parallel.
- *   Otherwise, run scripts in sequencial.
- *   Default is `false`.
- * @param {stream.Readable|null} options.stdin -
- *   A readable stream to send messages to stdin of child process.
- *   If this is `null`, ignores it.
- *   If this is `process.stdin`, inherits it.
- *   Otherwise, makes a pipe.
- *   Default is `null`.
- * @param {stream.Writable|null} options.stdout -
- *   A writable stream to receive messages from stdout of child process.
- *   If this is `null`, cannot send.
- *   If this is `process.stdout`, inherits it.
- *   Otherwise, makes a pipe.
- *   Default is `null`.
- * @param {stream.Writable|null} options.stderr -
- *   A writable stream to receive messages from stderr of child process.
- *   If this is `null`, cannot send.
- *   If this is `process.stderr`, inherits it.
- *   Otherwise, makes a pipe.
- *   Default is `null`.
- * @param {string[]} options.taskList -
- *   Actual name list of npm-scripts.
- *   This function search npm-script names in this list.
- *   If this is `null`, this function reads `package.json` of current directly.
- * @param {object|null} options.packageConfig -
- *   A map-like object to overwrite package configs.
- *   Keys are package names.
- *   Every value is a map-like object (Pairs of variable name and value).
- *   e.g. `{"npm-run-all": {"test": 777}}`
- *   Default is `null`.
- * @param {boolean} options.silent -
- *   The flag to set `silent` to the log level of npm.
- *   Default is `false`.
- * @param {boolean} options.continueOnError -
- *   The flag to ignore errors.
- *   Default is `false`.
- * @param {boolean} options.printLabel -
- *   The flag to print task names at the head of each line.
- *   Default is `false`.
- * @param {boolean} options.printName -
- *   The flag to print task names before running each task.
- *   Default is `false`.
- * @param {number} options.maxParallel -
- *   The maximum number of parallelism.
- *   Default is unlimited.
- * @param {string} options.npmPath -
- *   The path to npm.
- *   Default is `process.env.npm_execpath`.
+ * @param {object} [options] - Various flags and streams.
+ * @param {boolean} options.parallel
+ * @param {stream.Readable|null} options.stdin
+ * @param {stream.Writable|null} options.stdout
+ * @param {stream.Writable|null} options.stderr
+ * @param {object} options.config
+ * @param {object} options.packageConfig
+ * @param {boolean} options.continueOnError
+ * @param {boolean} options.printLabel
+ * @param {boolean} options.printName
+ * @param {boolean} options.race
+ * @param {number} options.maxParallel
+ * @param {boolean} options.aggregateOutput
+ * @param {string} options.npmPath
+ * @param {number} options.retry
+ * @param {boolean} options.summary
  * @returns {Promise}
- *   A promise object which becomes fullfilled when all npm-scripts are completed.
  */
-module.exports = function npmRunAll(patternOrPatterns, options) { //eslint-disable-line complexity
-    const stdin = (options && options.stdin) || null
-    const stdout = (options && options.stdout) || null
-    const stderr = (options && options.stderr) || null
-    const taskList = (options && options.taskList) || null
-    const config = (options && options.config) || null
-    const packageConfig = (options && options.packageConfig) || null
-    const args = (options && options.arguments) || []
-    const parallel = Boolean(options && options.parallel)
-    const silent = Boolean(options && options.silent)
-    const continueOnError = Boolean(options && options.continueOnError)
-    const printLabel = Boolean(options && options.printLabel)
-    const printName = Boolean(options && options.printName)
-    const race = Boolean(options && options.race)
-    const maxParallel = parallel ? ((options && options.maxParallel) || 0) : 1
-    const aggregateOutput = Boolean(options && options.aggregateOutput)
-    const npmPath = options && options.npmPath
-    try {
-        const patterns = parsePatterns(patternOrPatterns, args)
-        if (patterns.length === 0) {
-            return Promise.resolve(null)
-        }
-        if (taskList != null && Array.isArray(taskList) === false) {
-            throw new Error("Invalid options.taskList")
-        }
-        if (typeof maxParallel !== "number" || !(maxParallel >= 0)) {
-            throw new Error("Invalid options.maxParallel")
-        }
-        if (!parallel && aggregateOutput) {
-            throw new Error("Invalid options.aggregateOutput; It requires options.parallel")
-        }
-        if (!parallel && race) {
-            throw new Error("Invalid options.race; It requires options.parallel")
-        }
+module.exports = function npmRunAll(patternOrPatterns, options) {
+  options = options || {}
+  const silent = Boolean(options.silent)
+  const stdin = options.stdin || null
+  const aggregateOutput = Boolean(options.aggregateOutput)
+  const stdout = silent && !aggregateOutput ? createNullStream() : options.stdout || null
+  const stderr = silent && !aggregateOutput ? createNullStream() : options.stderr || null
+  const taskList = options.taskList || null
+  const config = options.config || null
+  const packageConfig = options.packageConfig || null
+  const args = options.arguments || []
+  const parallel = Boolean(options.parallel)
+  const continueOnError = Boolean(options.continueOnError)
+  const printLabel = Boolean(options.printLabel)
+  const printName = Boolean(options.printName)
+  const race = Boolean(options.race)
+  const maxParallel = parallel ? options.maxParallel || 0 : 1
+  const npmPath = options.npmPath
+  const retry = Number(options.retry) || 0
+  const summary = Boolean(options.summary)
 
-        const prefixOptions = [].concat(
-            silent ? ["--silent"] : [],
-            packageConfig ? toOverwriteOptions(packageConfig) : [],
-            config ? toConfigOptions(config) : []
-        )
-
-        return Promise.resolve()
-            .then(() => {
-                if (taskList != null) {
-                    return { taskList, packageInfo: null }
-                }
-                return readPackageJson()
-            })
-            .then(x => {
-                const tasks = matchTasks(x.taskList, patterns)
-                const labelWidth = tasks.reduce(maxLength, 0)
-
-                return runTasks(tasks, {
-                    stdin,
-                    stdout,
-                    stderr,
-                    prefixOptions,
-                    continueOnError,
-                    labelState: {
-                        enabled: printLabel,
-                        width: labelWidth,
-                        lastPrefix: null,
-                        lastIsLinebreak: true,
-                    },
-                    printName,
-                    packageInfo: x.packageInfo,
-                    race,
-                    maxParallel,
-                    npmPath,
-                    aggregateOutput,
-                })
-            })
+  try {
+    const patterns = parsePatterns(patternOrPatterns, args)
+    if (patterns.length === 0) {
+      return Promise.resolve(null)
     }
-    catch (err) {
-        return Promise.reject(new Error(err.message))
+    if (taskList != null && !Array.isArray(taskList)) {
+      throw new Error("Invalid options.taskList")
     }
+    if (typeof maxParallel !== "number" || maxParallel < 0) {
+      throw new Error("Invalid options.maxParallel")
+    }
+    if (!parallel && aggregateOutput) {
+      throw new Error("Invalid options.aggregateOutput; It requires parallel")
+    }
+    if (!parallel && race) {
+      throw new Error("Invalid options.race; It requires parallel")
+    }
+
+    const prefixOptions = []
+      .concat(silent ? ["--silent"] : [])
+      .concat(packageConfig ? toOverwriteOptions(packageConfig) : [])
+      .concat(config ? toConfigOptions(config) : [])
+
+    return Promise.resolve()
+      .then(() => {
+        if (taskList != null) {
+          return { taskList, packageInfo: null }
+        }
+        return readPackageJson()
+      })
+      .then((x) => {
+        const tasks = matchTasks(x.taskList, patterns)
+        const labelWidth = tasks.reduce(maxLength, 0)
+
+        const runOpts = {
+          stdin,
+          stdout,
+          stderr,
+          prefixOptions,
+          continueOnError,
+          labelState: {
+            enabled: printLabel,
+            width: labelWidth,
+            lastPrefix: null,
+            lastIsLinebreak: true
+          },
+          printName,
+          packageInfo: x.packageInfo,
+          race,
+          maxParallel,
+          npmPath,
+          aggregateOutput,
+          retry,
+          summary
+        }
+        return runTasks(tasks, runOpts)
+      })
+  } catch (err) {
+    return Promise.reject(new Error(err.message))
+  }
 }

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -34,13 +34,13 @@ const taskNamesToColors = new Map()
  * @returns {function} A colorize function that provided by `chalk`
  */
 function selectColor(taskName) {
-    let color = taskNamesToColors.get(taskName)
-    if (!color) {
-        color = colors[colorIndex]
-        colorIndex = (colorIndex + 1) % colors.length
-        taskNamesToColors.set(taskName, color)
-    }
-    return color
+  let color = taskNamesToColors.get(taskName)
+  if (!color) {
+    color = colors[colorIndex]
+    colorIndex = (colorIndex + 1) % colors.length
+    taskNamesToColors.set(taskName, color)
+  }
+  return color
 }
 
 /**
@@ -52,18 +52,18 @@ function selectColor(taskName) {
  * @returns {stream.Writable} `source` or the created wrapped stream.
  */
 function wrapLabeling(taskName, source, labelState) {
-    if (source == null || !labelState.enabled) {
-        return source
-    }
+  if (source == null || !labelState.enabled) {
+    return source
+  }
 
-    const label = padEnd(taskName, labelState.width)
-    const color = source.isTTY ? selectColor(taskName) : (x) => x
-    const prefix = color(`[${label}] `)
-    const stream = createPrefixTransform(prefix, labelState)
+  const label = padEnd(taskName, labelState.width)
+  const color = source.isTTY ? selectColor(taskName) : (x) => x
+  const prefix = color(`[${label}] `)
+  const stream = createPrefixTransform(prefix, labelState)
 
-    stream.pipe(source)
+  stream.pipe(source)
 
-    return stream
+  return stream
 }
 
 /**
@@ -74,12 +74,12 @@ function wrapLabeling(taskName, source, labelState) {
  * @returns {string|stream.Readable|stream.Writable} An option for `child_process.spawn`.
  */
 function detectStreamKind(stream, std) {
-    return (
-        stream == null ? "ignore" :
-        // `|| !std.isTTY` is needed for the workaround of https://github.com/nodejs/node/issues/5620
-        stream !== std || !std.isTTY ? "pipe" :
-        /* else */ stream
-    )
+  return stream == null
+    ? "ignore"
+    : // `|| !std.isTTY` is needed for the workaround of https://github.com/nodejs/node/issues/5620
+      stream !== std || !std.isTTY
+      ? "pipe"
+      : /* else */ stream
 }
 
 /**
@@ -95,7 +95,7 @@ function detectStreamKind(stream, std) {
  * @returns {string} A valid argument for npm-cli.
  */
 function cleanTaskArg(arg) {
-    return arg.pattern || arg.op || arg
+  return arg.pattern || arg.op || arg
 }
 
 //------------------------------------------------------------------------------
@@ -134,73 +134,69 @@ function cleanTaskArg(arg) {
  * @private
  */
 module.exports = function runTask(task, options) {
-    let cp = null
-    const promise = new Promise((resolve, reject) => {
-        const stdin = options.stdin
-        const stdout = wrapLabeling(task, options.stdout, options.labelState)
-        const stderr = wrapLabeling(task, options.stderr, options.labelState)
-        const stdinKind = detectStreamKind(stdin, process.stdin)
-        const stdoutKind = detectStreamKind(stdout, process.stdout)
-        const stderrKind = detectStreamKind(stderr, process.stderr)
-        const spawnOptions = { stdio: [stdinKind, stdoutKind, stderrKind] }
+  let cp = null
+  const promise = new Promise((resolve, reject) => {
+    const stdin = options.stdin
+    const stdout = wrapLabeling(task, options.stdout, options.labelState)
+    const stderr = wrapLabeling(task, options.stderr, options.labelState)
+    const stdinKind = detectStreamKind(stdin, process.stdin)
+    const stdoutKind = detectStreamKind(stdout, process.stdout)
+    const stderrKind = detectStreamKind(stderr, process.stderr)
+    const spawnOptions = { stdio: [stdinKind, stdoutKind, stderrKind] }
 
-        // Print task name.
-        if (options.printName && stdout != null) {
-            stdout.write(createHeader(
-                task,
-                options.packageInfo,
-                options.stdout.isTTY
-            ))
-        }
-
-        // Execute.
-        const npmPath = options.npmPath || process.env.npm_execpath //eslint-disable-line no-process-env
-        const npmPathIsJs = typeof npmPath === "string" && /\.m?js/.test(path.extname(npmPath))
-        const execPath = (npmPathIsJs ? process.execPath : npmPath || "npm")
-        const isYarn = path.basename(npmPath || "npm").startsWith("yarn")
-        const spawnArgs = ["run"]
-
-        if (npmPathIsJs) {
-            spawnArgs.unshift(npmPath)
-        }
-        if (!isYarn) {
-            Array.prototype.push.apply(spawnArgs, options.prefixOptions)
-        }
-        else if (options.prefixOptions.indexOf("--silent") !== -1) {
-            spawnArgs.push("--silent")
-        }
-        Array.prototype.push.apply(spawnArgs, parseArgs(task).map(cleanTaskArg))
-
-        cp = spawn(execPath, spawnArgs, spawnOptions)
-
-        // Piping stdio.
-        if (stdinKind === "pipe") {
-            stdin.pipe(cp.stdin)
-        }
-        if (stdoutKind === "pipe") {
-            cp.stdout.pipe(stdout, { end: false })
-        }
-        if (stderrKind === "pipe") {
-            cp.stderr.pipe(stderr, { end: false })
-        }
-
-        // Register
-        cp.on("error", (err) => {
-            cp = null
-            reject(err)
-        })
-        cp.on("close", (code, signal) => {
-            cp = null
-            resolve({ task, code, signal })
-        })
-    })
-
-    promise.abort = function abort() {
-        if (cp != null) {
-            cp.kill()
-            cp = null
-        }
+    // Print task name.
+    if (options.printName && stdout != null) {
+      stdout.write(createHeader(task, options.packageInfo, options.stdout.isTTY))
     }
 
-    return promise
+    // Execute.
+    const npmPath = options.npmPath || process.env.npm_execpath
+    const npmPathIsJs = typeof npmPath === "string" && /\.m?js/.test(path.extname(npmPath))
+    const execPath = npmPathIsJs ? process.execPath : npmPath || "npm"
+    const isYarn = path.basename(npmPath || "npm").startsWith("yarn")
+    const spawnArgs = ["run"]
+
+    if (npmPathIsJs) {
+      spawnArgs.unshift(npmPath)
+    }
+    if (!isYarn) {
+      console.log(options.prefixOptions)
+      Array.prototype.push.apply(spawnArgs, options.prefixOptions)
+    } else if (options.prefixOptions.indexOf("--silent") !== -1) {
+      spawnArgs.push("--silent")
+    }
+    Array.prototype.push.apply(spawnArgs, parseArgs(task).map(cleanTaskArg))
+
+    cp = spawn(execPath, spawnArgs, spawnOptions)
+
+    // Piping stdio.
+    if (stdinKind === "pipe") {
+      stdin.pipe(cp.stdin)
+    }
+    if (stdoutKind === "pipe") {
+      cp.stdout.pipe(stdout, { end: false })
+    }
+    if (stderrKind === "pipe") {
+      cp.stderr.pipe(stderr, { end: false })
+    }
+
+    // Register
+    cp.on("error", (err) => {
+      cp = null
+      reject(err)
+    })
+    cp.on("close", (code) => {
+      cp = null
+      resolve({ task, code })
+    })
+  })
+
+  promise.abort = function abort() {
+    if (cp != null) {
+      cp.kill()
+      cp = null
+    }
+  }
+
+  return promise
 }

--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 const MemoryStream = require("memorystream")
+const chalk = require("chalk")
 const NpmRunAllError = require("./npm-run-all-error")
 const runTask = require("./run-task")
 
@@ -19,50 +20,55 @@ const runTask = require("./run-task")
 //------------------------------------------------------------------------------
 
 /**
- * Remove the given value from the array.
+ * Rimuove il valore x dall'array.
  * @template T
- * @param {T[]} array - The array to remove.
- * @param {T} x - The item to be removed.
- * @returns {void}
+ * @param {T[]} array
+ * @param {T} x
  */
 function remove(array, x) {
-    const index = array.indexOf(x)
-    if (index !== -1) {
-        array.splice(index, 1)
-    }
-}
-
-const signals = {
-    SIGABRT: 6,
-    SIGALRM: 14,
-    SIGBUS: 10,
-    SIGCHLD: 20,
-    SIGCONT: 19,
-    SIGFPE: 8,
-    SIGHUP: 1,
-    SIGILL: 4,
-    SIGINT: 2,
-    SIGKILL: 9,
-    SIGPIPE: 13,
-    SIGQUIT: 3,
-    SIGSEGV: 11,
-    SIGSTOP: 17,
-    SIGTERM: 15,
-    SIGTRAP: 5,
-    SIGTSTP: 18,
-    SIGTTIN: 21,
-    SIGTTOU: 22,
-    SIGUSR1: 30,
-    SIGUSR2: 31,
+  const idx = array.indexOf(x)
+  if (idx !== -1) array.splice(idx, 1)
 }
 
 /**
- * Converts a signal name to a number.
- * @param {string} signal - the signal name to convert into a number
- * @returns {number} - the return code for the signal
+ * Stampa a console una tabella ASCII con colonne Task, FinalExitCode, Retries, Time(s),
+ * preceduta da un header "Summary".
+ * @param {Array<{name:string,code:number,retries:number,durationMs:number}>} results
  */
-function convert(signal) {
-    return signals[signal] || 0
+function printSummaryTable(results) {
+  const headers = ["Task", "FinalExitCode", "Retries", "Time(s)"]
+  const rows = results.map(({ name, code, retries, durationMs }) => [name, String(code), String(retries), (durationMs / 1000).toFixed(2)])
+  const table = [headers, ...rows]
+
+  // calcola la larghezza di ciascuna colonna
+  const colWidths = headers.map((_, i) => Math.max(...table.map((row) => row[i].length)))
+
+  // linea di separazione esterna
+  const divider = "+" + colWidths.map((w) => "-".repeat(w + 2)).join("+") + "+"
+
+  // stampa header "Summary" centrato/left-aligned nella larghezza totale
+  console.log("\n" + divider)
+  const totalInnerWidth = divider.length - 2
+  const summaryText = "Summary"
+  const padding = totalInnerWidth - summaryText.length
+  console.log("|" + " " + summaryText + " ".repeat(padding) + "|")
+  console.log(divider)
+
+  // righe di intestazione colonne
+  const headerLine = "|" + headers.map((h, i) => " " + h.padEnd(colWidths[i]) + " ").join("|") + "|"
+  // linea di separazione sotto le intestazioni
+  const separator = "|" + colWidths.map((w) => " " + "-".repeat(w).padEnd(w) + " ").join("|") + "|"
+
+  console.log(headerLine)
+  console.log(separator)
+
+  // righe dei dati
+  rows.forEach((row) => {
+    console.log("|" + row.map((cell, i) => " " + cell.padEnd(colWidths[i]) + " ").join("|") + "|")
+  })
+
+  // linea di chiusura
+  console.log(divider)
 }
 
 //------------------------------------------------------------------------------
@@ -70,150 +76,177 @@ function convert(signal) {
 //------------------------------------------------------------------------------
 
 /**
- * Run npm-scripts of given names in parallel.
+ * Esegue in parallelo i task con supporto retry e poi, se options.summary è true,
+ * stampa un riepilogo tabellare.
  *
- * If a npm-script exited with a non-zero code, this aborts other all npm-scripts.
- *
- * @param {string} tasks - A list of npm-script name to run in parallel.
- * @param {object} options - An option object.
- * @returns {Promise} A promise object which becomes fullfilled when all npm-scripts are completed.
- * @private
+ * @param {string[]} tasks
+ * @param {object} options include options.retry, options.continueOnError,
+ *   options.summary (boolean), options.parallel, ecc.
+ * @returns {Promise<object[]>}
  */
 module.exports = function runTasks(tasks, options) {
-    return new Promise((resolve, reject) => {
-        if (tasks.length === 0) {
-            resolve([])
+  const showSummary = Boolean(options.summary)
+
+  return new Promise((resolve, reject) => {
+    if (!Array.isArray(tasks) || tasks.length === 0) {
+      if (showSummary) {
+        printSummaryTable([])
+      }
+      resolve([])
+      return
+    }
+
+    const results = tasks.map((name) => ({
+      name,
+      code: undefined,
+      retries: 0,
+      durationMs: 0
+    }))
+    const queue = tasks.map((name, idx) => ({ name, index: idx }))
+    const promises = []
+    let error = null
+    let aborted = false
+    const maxRetries = Number(options.retry) || 0
+
+    async function attemptRun(name, opts) {
+      const start = Date.now()
+      let lastResult = { name, code: 1 }
+      let retries = 0
+
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+          lastResult = await runTask(name, opts)
+        } catch {
+          lastResult = { name, code: 1 }
+        }
+
+        if (lastResult.code === 0) {
+          const durationMs = Date.now() - start
+          return { name, code: 0, retries, durationMs }
+        }
+
+        // log fallimento
+        opts.stderr.write(chalk.yellow("›") + ` ${chalk.bold(name)} failed with exit code ${lastResult.code}\n`)
+
+        // se posso riprovare, incremento retries e stampo retry
+        if (attempt < maxRetries) {
+          retries += 1
+          opts.stderr.write(chalk.yellow("›") + ` retrying ${chalk.bold(name)} (${retries}/${maxRetries})\n`)
+        }
+      }
+
+      // Exhausted retries
+      const durationMs = Date.now() - start
+      const msg = `Task "${name}" failed after ${maxRetries + 1} attempts (code: ${lastResult.code})`
+
+      if (opts.continueOnError) {
+        return { name, code: lastResult.code, retries, durationMs }
+      }
+
+      const err = new Error(msg)
+      err.retries = retries
+      err.durationMs = durationMs
+      throw err
+    }
+
+    function abort() {
+      if (aborted) return
+      aborted = true
+      if (promises.length === 0) {
+        done()
+      } else {
+        for (const p of promises) {
+          if (typeof p.abort === "function") p.abort()
+        }
+        Promise.all(promises).then(done, reject)
+      }
+    }
+
+    function done() {
+      if (showSummary) {
+        printSummaryTable(results)
+      }
+
+      if (error != null) {
+        reject(error)
+      } else {
+        const failures = results.filter((r) => r.code !== 0)
+        if (failures.length > 0) {
+          const msgs = failures.map((r) => `"${r.name}" exited with ${r.code}`)
+          reject(new Error(msgs.join(" & ")))
+        } else {
+          resolve(results)
+        }
+      }
+    }
+
+    function next() {
+      if (aborted) return
+      if (queue.length === 0) {
+        if (promises.length === 0) done()
+        return
+      }
+
+      const { name, index } = queue.shift()
+      const opts = Object.assign({}, options)
+      let writer = null
+
+      if (opts.aggregateOutput && opts.stdout) {
+        // Bufferizziamo sia stdout che stderr per questo task
+        writer = new MemoryStream(null, { readable: false })
+        opts.stdout = writer
+        opts.stderr = writer
+      }
+
+      const p = attemptRun(name, opts)
+      promises.push(p)
+
+      p.then((result) => {
+        remove(promises, p)
+        if (aborted) return
+
+        // Appena il task finisce, svuotiamo il buffer e lo scriviamo tutto
+        if (writer && options.stdout) {
+          options.stdout.write(writer.toString())
+        }
+
+        // Aggiorniamo i dati per il riepilogo
+        results[index].code = result.code
+        results[index].retries = result.retries
+        results[index].durationMs = result.durationMs
+
+        if (result.code) {
+          if (!options.continueOnError) {
+            error = new NpmRunAllError(result, results)
+            abort()
             return
+          }
         }
 
-        const results = tasks.map(task => ({ name: task, code: undefined }))
-        const queue = tasks.map((task, index) => ({ name: task, index }))
-        const promises = []
-        let error = null
-        let aborted = false
-
-        /**
-         * Done.
-         * @returns {void}
-         */
-        function done() {
-            if (error == null) {
-                resolve(results)
-            }
-            else {
-                reject(error)
-            }
+        if (options.race && result.code === 0) {
+          error = null
+          abort()
+          return
         }
 
-        /**
-         * Aborts all tasks.
-         * @returns {void}
-         */
-        function abort() {
-            if (aborted) {
-                return
-            }
-            aborted = true
-
-            if (promises.length === 0) {
-                done()
-            }
-            else {
-                for (const p of promises) {
-                    p.abort()
-                }
-                Promise.all(promises).then(done, reject)
-            }
+        next()
+      }).catch((err) => {
+        remove(promises, p)
+        if (!options.continueOnError || options.race) {
+          error = err
+          abort()
+        } else {
+          next()
         }
+      })
+    }
 
-        /**
-         * Runs a next task.
-         * @returns {void}
-         */
-        function next() {
-            if (aborted) {
-                return
-            }
-            if (queue.length === 0) {
-                if (promises.length === 0) {
-                    done()
-                }
-                return
-            }
+    // Avvio parallelo fino a maxParallel
+    const max = options.maxParallel
+    const initial = typeof max === "number" && max > 0 ? Math.min(tasks.length, max) : tasks.length
 
-            const originalOutputStream = options.stdout
-            const optionsClone = Object.assign({}, options)
-            const writer = new MemoryStream(null, {
-                readable: false,
-            })
-
-            if (options.aggregateOutput) {
-                optionsClone.stdout = writer
-            }
-
-            const task = queue.shift()
-            const promise = runTask(task.name, optionsClone)
-
-            promises.push(promise)
-            promise.then(
-                (result) => {
-                    remove(promises, promise)
-                    if (aborted) {
-                        return
-                    }
-
-                    if (options.aggregateOutput) {
-                        originalOutputStream.write(writer.toString())
-                    }
-
-                    // Check if the task failed as a result of a signal, and
-                    // amend the exit code as a result.
-                    if (result.code === null && result.signal !== null) {
-                        // An exit caused by a signal must return a status code
-                        // of 128 plus the value of the signal code.
-                        // Ref: https://nodejs.org/api/process.html#process_exit_codes
-                        result.code = 128 + convert(result.signal)
-                    }
-
-                    // Save the result.
-                    results[task.index].code = result.code
-
-                    // Aborts all tasks if it's an error.
-                    if (result.code) {
-                        error = new NpmRunAllError(result, results)
-                        if (!options.continueOnError) {
-                            abort()
-                            return
-                        }
-                    }
-
-                    // Aborts all tasks if options.race is true.
-                    if (options.race && !result.code) {
-                        abort()
-                        return
-                    }
-
-                    // Call the next task.
-                    next()
-                },
-                (thisError) => {
-                    remove(promises, promise)
-                    if (!options.continueOnError || options.race) {
-                        error = thisError
-                        abort()
-                        return
-                    }
-                    next()
-                }
-            )
-        }
-
-        const max = options.maxParallel
-        const end = (typeof max === "number" && max > 0)
-            ? Math.min(tasks.length, max)
-            : tasks.length
-        for (let i = 0; i < end; ++i) {
-            next()
-        }
-    })
+    for (let i = 0; i < initial; i++) {
+      next()
+    }
+  })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,7936 @@
+{
+  "name": "npm-run-all",
+  "version": "4.1.5",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-run-all",
+      "version": "4.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "@mysticatea/eslint-plugin": "^13.0.0",
+        "ansi-styles": "^6.2.1",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.6",
+        "memorystream": "^0.3.1",
+        "minimatch": "^10.0.1",
+        "npm-check-updates": "^18.0.1",
+        "pidtree": "^0.6.0",
+        "read-pkg": "^5.2.0",
+        "shell-quote": "^1.8.2",
+        "string.prototype.padend": "^3.1.6"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.27.0",
+        "@babel/core": "^7.26.10",
+        "@babel/node": "^7.26.0",
+        "@babel/preset-env": "^7.26.9",
+        "@babel/register": "^7.25.9",
+        "@types/node": "^22.15.3",
+        "eslint": "^9.25.1",
+        "fs-extra": "^11.3.0",
+        "mocha": "^11.1.0",
+        "nyc": "^17.1.0",
+        "p-queue": "^8.1.0",
+        "rimraf": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/cli": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.0.tgz",
+      "integrity": "sha512-bZfxn8DRxwiVzDO5CEeV+7IqXeCkzI4yYnrQbpwjT76CUyossQc6RYE7n+xfm0/2k40lPaCpW0FhxYs7EBAetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "commander": "^6.2.0",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.6.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.26.8",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.26.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.27.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-fO8l08T76v48BhpNRW/nQ0MxfnSdoSKUJBMjubOAYffsVuGG5qOfMq7N6Es7UJvi7Y8goXXo07EfcHZXDPuELQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "regexpu-core": "^6.2.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
+      "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.22.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-wrap-function": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/node": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.26.0.tgz",
+      "integrity": "sha512-5ASMjh42hbnqyCOK68Q5chh1jKAqn91IswFTN+niwt4FLABhEWCT1tEuuo6mlNQ4WG/oFQLvJ71PaHAKtWtJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/register": "^7.25.9",
+        "commander": "^6.2.0",
+        "core-js": "^3.30.2",
+        "node-environment-flags": "^1.0.5",
+        "regenerator-runtime": "^0.14.0",
+        "v8flags": "^3.1.1"
+      },
+      "bin": {
+        "babel-node": "bin/babel-node.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
+      "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
+      "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
+      "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/plugin-transform-optional-chaining": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
+      "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+      "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+      "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-remap-async-to-generator": "^7.25.9",
+        "@babel/traverse": "^7.26.8"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-remap-async-to-generator": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+      "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.0.tgz",
+      "integrity": "sha512-u1jGphZ8uDI2Pj/HJj6YQ6XQLZCNjOlprjxB5SVz6rq2T6SwAR+CdrWK0CP7F+9rDVMXdB0+r6Am5G5aobOjAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
+      "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/template": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
+      "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
+      "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
+      "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
+      "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
+      "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+      "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
+      "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
+      "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+      "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
+      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
+      "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
+      "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.26.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
+      "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
+      "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-transform-parameters": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
+      "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+      "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.0.tgz",
+      "integrity": "sha512-LX/vCajUJQDqE7Aum/ELUMZAY19+cDpghxrnyt5I1tV6X5PyC86AOoWXWFYFeIvauyeSA6/ktn4tQVn/3ZifsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "regenerator-transform": "^0.15.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
+      "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
+      "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+      "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.0.tgz",
+      "integrity": "sha512-+LLkxA9rKJpNoGsbLnAgOCdESl73vwYn+V6b+5wHbrE7OGKVDPHIQvbFSzqE6rwqaCw2RE+zdJrlLkcf8YOA0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
+      "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
+      "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
+      "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
+      "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
+      "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.26.8",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/plugin-syntax-import-attributes": "^7.26.0",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.25.9",
+        "@babel/plugin-transform-async-generator-functions": "^7.26.8",
+        "@babel/plugin-transform-async-to-generator": "^7.25.9",
+        "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
+        "@babel/plugin-transform-block-scoping": "^7.25.9",
+        "@babel/plugin-transform-class-properties": "^7.25.9",
+        "@babel/plugin-transform-class-static-block": "^7.26.0",
+        "@babel/plugin-transform-classes": "^7.25.9",
+        "@babel/plugin-transform-computed-properties": "^7.25.9",
+        "@babel/plugin-transform-destructuring": "^7.25.9",
+        "@babel/plugin-transform-dotall-regex": "^7.25.9",
+        "@babel/plugin-transform-duplicate-keys": "^7.25.9",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
+        "@babel/plugin-transform-dynamic-import": "^7.25.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-for-of": "^7.26.9",
+        "@babel/plugin-transform-function-name": "^7.25.9",
+        "@babel/plugin-transform-json-strings": "^7.25.9",
+        "@babel/plugin-transform-literals": "^7.25.9",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.25.9",
+        "@babel/plugin-transform-modules-amd": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.25.9",
+        "@babel/plugin-transform-modules-umd": "^7.25.9",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
+        "@babel/plugin-transform-new-target": "^7.25.9",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
+        "@babel/plugin-transform-numeric-separator": "^7.25.9",
+        "@babel/plugin-transform-object-rest-spread": "^7.25.9",
+        "@babel/plugin-transform-object-super": "^7.25.9",
+        "@babel/plugin-transform-optional-catch-binding": "^7.25.9",
+        "@babel/plugin-transform-optional-chaining": "^7.25.9",
+        "@babel/plugin-transform-parameters": "^7.25.9",
+        "@babel/plugin-transform-private-methods": "^7.25.9",
+        "@babel/plugin-transform-private-property-in-object": "^7.25.9",
+        "@babel/plugin-transform-property-literals": "^7.25.9",
+        "@babel/plugin-transform-regenerator": "^7.25.9",
+        "@babel/plugin-transform-regexp-modifiers": "^7.26.0",
+        "@babel/plugin-transform-reserved-words": "^7.25.9",
+        "@babel/plugin-transform-shorthand-properties": "^7.25.9",
+        "@babel/plugin-transform-spread": "^7.25.9",
+        "@babel/plugin-transform-sticky-regex": "^7.25.9",
+        "@babel/plugin-transform-template-literals": "^7.26.8",
+        "@babel/plugin-transform-typeof-symbol": "^7.26.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.25.9",
+        "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
+        "@babel/plugin-transform-unicode-regex": "^7.25.9",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.10",
+        "babel-plugin-polyfill-corejs3": "^0.11.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.1",
+        "core-js-compat": "^3.40.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
+      "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
+      "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
+      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
+      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.13.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@mysticatea/eslint-plugin/-/eslint-plugin-13.0.0.tgz",
+      "integrity": "sha512-L0FAKWY+P46aYMacZolyuXJOcg9B5N6HvlB/vr5k+FRVGqaeciayH6YD5hOhgusyUUqgC776RVjtIMeumNVjQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "~2.6.1",
+        "@typescript-eslint/parser": "~2.6.1",
+        "eslint-plugin-eslint-comments": "~3.1.2",
+        "eslint-plugin-eslint-plugin": "~2.1.0",
+        "eslint-plugin-node": "~10.0.0",
+        "eslint-plugin-prettier": "~3.1.1",
+        "eslint-plugin-vue": "~6.0.0",
+        "prettier": "~1.19.1",
+        "vue-eslint-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.6.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz",
+      "integrity": "sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "2.6.1",
+        "eslint-utils": "^1.4.2",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.17.1"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^2.0.0",
+        "eslint": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/@typescript-eslint/parser": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.1.tgz",
+      "integrity": "sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "2.6.1",
+        "@typescript-eslint/typescript-estree": "2.6.1",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/acorn": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/eslint-plugin-vue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.0.2.tgz",
+      "integrity": "sha512-LF0AeuCjzTe+enkvvtvKClG3iYZwMKE3M6yEUZruUHNolLwqGqbEULzvMmojr+8KlMl//Ya1k7dKVt4HFASKfw==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-eslint-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": ">=8.10"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-6.0.5.tgz",
+      "integrity": "sha512-Bvjlx7rH1Ulvus56KHeLXOjEi3JMOYTa1GAqZr9lBQhd8weK8mV7U7V2l85yokBZEWHJQjLn6X3nosY8TzkOKg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.11"
+      },
+      "engines": {
+        "node": ">=6.5"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@mysticatea/eslint-plugin/node_modules/regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.5.0"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz",
+      "integrity": "sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.6.1",
+        "eslint-scope": "^5.0.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz",
+      "integrity": "sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.4",
+        "is-glob": "^4.0.1",
+        "lodash.unescape": "4.0.1",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz",
+      "integrity": "sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
+      "integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.22.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.4",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "core-js-compat": "^3.40.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
+      "integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/browserslist": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caching-transform/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
+      "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
+      "integrity": "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "license": "MIT"
+    },
+    "node_modules/default-require-extensions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.144",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.144.tgz",
+      "integrity": "sha512-eJIaMRKeAzxfBSxtjYnoIAw/tdD6VIH6tHBZepZnAbE3Gyqqs5mGN87DvcldPUbVkIljTK8pY0CMcUljP64lfQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
+      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.13.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.25.1",
+        "@eslint/plugin-kit": "^0.2.8",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-es": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz",
+      "integrity": "sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz",
+      "integrity": "sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-node": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-es": "^2.0.0",
+        "eslint-utils": "^1.4.2",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.0.0",
+        "prettier": ">=1.13.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT"
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "license": "ISC"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
+      "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "license": "MIT"
+    },
+    "node_modules/node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "node_modules/node-environment-flags/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-check-updates": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.1.tgz",
+      "integrity": "sha512-MO7mLp/8nm6kZNLLyPgz4gHmr9tLoU+pWPLdXuGAx+oZydBHkHWN0ibTonsrfwC2WEQNIQxuZagYwB67JQpAuw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ncu": "build/cli.js",
+        "npm-check-updates": "build/cli.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0",
+        "npm": ">=8.12.1"
+      }
+    },
+    "node_modules/nyc": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
+      "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^3.3.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.2",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nyc/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/nyc/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/nyc/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nyc/node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/nyc/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nyc/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nyc/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.8.tgz",
+      "integrity": "sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.6",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "gopd": "^1.0.1",
+        "safe-array-concat": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/process-on-spawn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+      "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerator-transform": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+      "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.0",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.12.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+      "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.0.2"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8flags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
+      "integrity": "sha512-qh3VhDLeh773wjgNTl7ss0VejY9bMMa0GoDG2fQVyDzRFdiU3L7fw74tWZDHNQXdZqxO3EveQroa9ct39D2nqg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.2.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-new.json
+++ b/package-new.json
@@ -14,10 +14,10 @@
     "docs"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">= 4"
   },
   "scripts": {
-    "_mocha": "mocha \"test/package-config.js\" --timeout 120000",
+    "_mocha": "mocha \"test/*.js\" --timeout 120000",
     "clean": "rimraf .nyc_output coverage jsdoc \"test-workspace/{build,test.txt}\"",
     "docs": "jsdoc -c jsdoc.json",
     "lint": "eslint bin lib scripts test \"test-workspace/tasks/*.js\"",
@@ -25,35 +25,34 @@
     "preversion": "npm test",
     "postversion": "git push && git push --tags",
     "test": "nyc --require @babel/register npm run _mocha",
-    "watch": "npm run _mocha -- --require @babel/register --watch",
+    "watch": "npm run _mocha -- --require @babel/register --watch --growl",
     "codecov": "nyc report -r lcovonly && codecov"
   },
   "dependencies": {
-    "@mysticatea/eslint-plugin": "^13.0.0",
     "ansi-styles": "^6.2.1",
     "chalk": "^4.1.2",
     "cross-spawn": "^7.0.6",
     "memorystream": "^0.3.1",
     "minimatch": "^10.0.1",
-    "npm-check-updates": "^18.0.1",
     "pidtree": "^0.6.0",
-    "read-pkg": "^5.2.0",
+    "read-pkg": "^9.0.1",
     "shell-quote": "^1.8.2",
     "string.prototype.padend": "^3.1.6"
   },
   "devDependencies": {
-    "@babel/cli": "^7.27.0",
-    "@babel/core": "^7.26.10",
-    "@babel/node": "^7.26.0",
-    "@babel/preset-env": "^7.26.9",
-    "@babel/register": "^7.25.9",
     "@types/node": "^22.15.3",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-preset-power-assert": "^3.0.0",
+    "@babel/register": "^7.25.9",
     "eslint": "^9.25.1",
+    "@mysticatea/eslint-plugin": "^13.0.0",
     "fs-extra": "^11.3.0",
     "mocha": "^11.1.0",
     "nyc": "^17.1.0",
     "p-queue": "^8.1.0",
-    "rimraf": "^6.0.1"
+    "power-assert": "^1.6.1",
+    "rimraf": "^6.0.1",
+    "yarn": "^1.22.22"
   },
   "repository": "mysticatea/npm-run-all",
   "keywords": [

--- a/test/aggregate-output.js
+++ b/test/aggregate-output.js
@@ -1,4 +1,3 @@
-
 /**
  * @author Toru Nagashima
  * @copyright 2016 Toru Nagashima. All rights reserved.
@@ -10,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const BufferStream = require("./lib/buffer-stream")
 const util = require("./lib/util")
@@ -23,99 +22,67 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[aggregated-output] npm-run-all", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    /**
-     * create expected text
-     * @param {string} term  the term to use when creating a line
-     * @returns {string} the complete line
-     */
-    function createExpectedOutput(term) {
-        return `[${term}]__[${term}]`
-    }
+  /**
+   * create expected text
+   * @param {string} term  the term to use when creating a line
+   * @returns {string} the complete line
+   */
+  function createExpectedOutput(term) {
+    return `[${term}]__[${term}]`
+  }
 
-    describe("should not intermingle output of various commands", () => {
-        const EXPECTED_PARALLELIZED_TEXT = [
-            createExpectedOutput("second"),
-            createExpectedOutput("third"),
-            createExpectedOutput("first"),
-            "",
-        ].join("\n")
+  describe("should not intermingle output of various commands", () => {
+    const EXPECTED_PARALLELIZED_TEXT = [createExpectedOutput("second"), createExpectedOutput("third"), createExpectedOutput("first"), ""].join("\n")
 
-        let stdout = null
+    let stdout = null
 
-        beforeEach(() => {
-            stdout = new BufferStream()
-        })
-
-        it("Node API with parallel", async () => {
-            await nodeApi(
-                ["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000"],
-                { stdout, parallel: true, silent: true, aggregateOutput: true }
-            )
-            assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
-        })
-
-        it("Node API without parallel should fail", async () => {
-            try {
-                await nodeApi(
-                    ["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000"],
-                    { stdout, silent: true, aggregateOutput: true }
-                )
-            }
-            catch (_err) {
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("npm-run-all command with parallel", async () => {
-            await runAll(
-                ["--parallel", "test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"],
-                stdout
-            )
-            assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
-        })
-
-        it("npm-run-all command without parallel should fail", async () => {
-            try {
-                await runAll(
-                    ["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"],
-                    stdout
-                )
-            }
-            catch (_err) {
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("run-s command should fail", async () => {
-            try {
-                await runSeq(
-                    ["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"],
-                    stdout
-                )
-            }
-            catch (_err) {
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("run-p command", async () => {
-            await runPar(
-                [
-                    "test-task:delayed first 5000",
-                    "test-task:delayed second 1000",
-                    "test-task:delayed third 3000",
-                    "--silent", "--aggregate-output",
-                ],
-                stdout
-            )
-            assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
-        })
+    beforeEach(() => {
+      stdout = new BufferStream()
     })
-})
 
+    it("Node API with parallel", async () => {
+      await nodeApi(["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000"], { stdout, parallel: true, silent: true, aggregateOutput: true })
+      assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
+    })
+
+    it("Node API without parallel should fail", async () => {
+      try {
+        await nodeApi(["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000"], { stdout, silent: true, aggregateOutput: true })
+      } catch (_err) {
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("npm-run-all command with parallel", async () => {
+      await runAll(["--parallel", "test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"], stdout)
+      assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
+    })
+
+    it("npm-run-all command without parallel should fail", async () => {
+      try {
+        await runAll(["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"], stdout)
+      } catch (_err) {
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("run-s command should fail", async () => {
+      try {
+        await runSeq(["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"], stdout)
+      } catch (_err) {
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:delayed first 5000", "test-task:delayed second 1000", "test-task:delayed third 3000", "--silent", "--aggregate-output"], stdout)
+      assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
+    })
+  })
+})

--- a/test/argument-placeholders.js
+++ b/test/argument-placeholders.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const util = require("./lib/util")
 const result = util.result
@@ -23,199 +23,94 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[argument-placeholders]", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
+  beforeEach(removeResult)
 
-    describe("If arguments preceded by '--' are nothing, '{1}' should be empty:", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {1}")
-                .then(() => assert(result() === "[]"))
-        )
+  describe("If arguments preceded by '--' are nothing, '{1}' should be empty:", () => {
+    it("Node API", () => nodeApi("test-task:dump {1}").then(() => assert(result() === "[]")))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {1}"])
-                .then(() => assert(result() === "[]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {1}"]).then(() => assert(result() === "[]")))
 
-        it("npm-run-all command (only '--' exists)", () =>
-            runAll(["test-task:dump {1}", "--"])
-                .then(() => assert(result() === "[]"))
-        )
+    it("npm-run-all command (only '--' exists)", () => runAll(["test-task:dump {1}", "--"]).then(() => assert(result() === "[]")))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {1}"])
-                .then(() => assert(result() === "[]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {1}"]).then(() => assert(result() === "[]")))
 
-        it("run-s command (only '--' exists)", () =>
-            runSeq(["test-task:dump {1}", "--"])
-                .then(() => assert(result() === "[]"))
-        )
+    it("run-s command (only '--' exists)", () => runSeq(["test-task:dump {1}", "--"]).then(() => assert(result() === "[]")))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {1}"])
-                .then(() => assert(result() === "[]"))
-        )
+    it("run-p command", () => runPar(["test-task:dump {1}"]).then(() => assert(result() === "[]")))
 
-        it("run-p command (only '--' exists)", () =>
-            runPar(["test-task:dump {1}", "--"])
-                .then(() => assert(result() === "[]"))
-        )
-    })
+    it("run-p command (only '--' exists)", () => runPar(["test-task:dump {1}", "--"]).then(() => assert(result() === "[]")))
+  })
 
-    describe("'{1}' should be replaced by the 1st argument preceded by '--':", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {1}", { arguments: ["1st", "2nd"] })
-                .then(() => assert(result() === "[\"1st\"]"))
-        )
+  describe("'{1}' should be replaced by the 1st argument preceded by '--':", () => {
+    it("Node API", () => nodeApi("test-task:dump {1}", { arguments: ["1st", "2nd"] }).then(() => assert(result() === '["1st"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {1}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {1}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {1}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {1}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {1}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {1}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st"]')))
+  })
 
-    describe("'{2}' should be replaced by the 2nd argument preceded by '--':", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {2}", { arguments: ["1st", "2nd"] })
-                .then(() => assert(result() === "[\"2nd\"]"))
-        )
+  describe("'{2}' should be replaced by the 2nd argument preceded by '--':", () => {
+    it("Node API", () => nodeApi("test-task:dump {2}", { arguments: ["1st", "2nd"] }).then(() => assert(result() === '["2nd"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {2}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"2nd\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {2}", "--", "1st", "2nd"]).then(() => assert(result() === '["2nd"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {2}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"2nd\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {2}", "--", "1st", "2nd"]).then(() => assert(result() === '["2nd"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {2}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"2nd\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {2}", "--", "1st", "2nd"]).then(() => assert(result() === '["2nd"]')))
+  })
 
-    describe("'{@}' should be replaced by the every argument preceded by '--':", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {@}", { arguments: ["1st", "2nd"] })
-                .then(() => assert(result() === "[\"1st\",\"2nd\"]"))
-        )
+  describe("'{@}' should be replaced by the every argument preceded by '--':", () => {
+    it("Node API", () => nodeApi("test-task:dump {@}", { arguments: ["1st", "2nd"] }).then(() => assert(result() === '["1st","2nd"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {@}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {@}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st","2nd"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {@}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {@}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st","2nd"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {@}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {@}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st","2nd"]')))
+  })
 
-    describe("'{*}' should be replaced by the all arguments preceded by '--':", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {*}", { arguments: ["1st", "2nd"] })
-                .then(() => assert(result() === "[\"1st 2nd\"]"))
-        )
+  describe("'{*}' should be replaced by the all arguments preceded by '--':", () => {
+    it("Node API", () => nodeApi("test-task:dump {*}", { arguments: ["1st", "2nd"] }).then(() => assert(result() === '["1st 2nd"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st 2nd\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {*}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st 2nd"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st 2nd\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {*}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st 2nd"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st 2nd\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {*}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st 2nd"]')))
+  })
 
-    describe("Every '{1}', '{2}', '{@}' and '{*}' should be replaced by the arguments preceded by '--':", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {1} {2} {3} {@} {*}", { arguments: ["1st", "2nd"] })
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
-        )
+  describe("Every '{1}', '{2}', '{@}' and '{*}' should be replaced by the arguments preceded by '--':", () => {
+    it("Node API", () => nodeApi("test-task:dump {1} {2} {3} {@} {*}", { arguments: ["1st", "2nd"] }).then(() => assert(result() === '["1st","2nd","1st","2nd","1st 2nd"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st","2nd","1st","2nd","1st 2nd"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st","2nd","1st","2nd","1st 2nd"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"]).then(() => assert(result() === '["1st","2nd","1st","2nd","1st 2nd"]')))
+  })
 
-    describe("'{1:-foo}' should be replaced by 'foo' if arguments are nothing:", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {1:-foo} {1}")
-                .then(() => assert(result() === "[\"foo\"]"))
-        )
+  describe("'{1:-foo}' should be replaced by 'foo' if arguments are nothing:", () => {
+    it("Node API", () => nodeApi("test-task:dump {1:-foo} {1}").then(() => assert(result() === '["foo"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {1:-foo} {1}"])
-                .then(() => assert(result() === "[\"foo\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {1:-foo} {1}"]).then(() => assert(result() === '["foo"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {1:-foo} {1}"])
-                .then(() => assert(result() === "[\"foo\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {1:-foo} {1}"]).then(() => assert(result() === '["foo"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {1:-foo} {1}"])
-                .then(() => assert(result() === "[\"foo\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {1:-foo} {1}"]).then(() => assert(result() === '["foo"]')))
+  })
 
-    describe("'{1:=foo}' should be replaced by 'foo' and should affect following '{1}' if arguments are nothing:", () => {
-        it("Node API", () =>
-            nodeApi("test-task:dump {1:=foo} {1}")
-                .then(() => assert(result() === "[\"foo\",\"foo\"]"))
-        )
+  describe("'{1:=foo}' should be replaced by 'foo' and should affect following '{1}' if arguments are nothing:", () => {
+    it("Node API", () => nodeApi("test-task:dump {1:=foo} {1}").then(() => assert(result() === '["foo","foo"]')))
 
-        it("npm-run-all command", () =>
-            runAll(["test-task:dump {1:=foo} {1}"])
-                .then(() => assert(result() === "[\"foo\",\"foo\"]"))
-        )
+    it("npm-run-all command", () => runAll(["test-task:dump {1:=foo} {1}"]).then(() => assert(result() === '["foo","foo"]')))
 
-        it("run-s command", () =>
-            runSeq(["test-task:dump {1:=foo} {1}"])
-                .then(() => assert(result() === "[\"foo\",\"foo\"]"))
-        )
+    it("run-s command", () => runSeq(["test-task:dump {1:=foo} {1}"]).then(() => assert(result() === '["foo","foo"]')))
 
-        it("run-p command", () =>
-            runPar(["test-task:dump {1:=foo} {1}"])
-                .then(() => assert(result() === "[\"foo\",\"foo\"]"))
-        )
-    })
+    it("run-p command", () => runPar(["test-task:dump {1:=foo} {1}"]).then(() => assert(result() === '["foo","foo"]')))
+  })
 })

--- a/test/bin/run-tests.js
+++ b/test/bin/run-tests.js
@@ -169,5 +169,5 @@ async function runMochaWithWorkspace(filePath) {
     process.stdout.write(`\n\nTOTAL: passing ${passing} failing ${failing} (${durationToText(process.uptime() - startInSec)})\n\n`)
 })().catch(error => {
     process.stderr.write(`\n\n${error.stack}\n\n`)
-    process.exit(1) //eslint-disable-line no-process-exit
+    process.exit(1)  
 })

--- a/test/common.js
+++ b/test/common.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const BufferStream = require("./lib/buffer-stream")
 const util = require("./lib/util")
@@ -24,316 +24,311 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[common]", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
+  beforeEach(removeResult)
 
-    describe("should print a help text if arguments are nothing.", () => {
-        it("npm-run-all command", async () => {
-            const buf = new BufferStream()
-            await runAll([], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("run-s command", async () => {
-            const buf = new BufferStream()
-            await runSeq([], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("run-p command", async () => {
-            const buf = new BufferStream()
-            await runPar([], buf)
-            assert(/Usage:/.test(buf.value))
-        })
+  describe("should print a help text if arguments are nothing.", () => {
+    it("npm-run-all command", async () => {
+      const buf = new BufferStream()
+      await runAll([], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("should print a help text if the first argument is --help (-h)", () => {
-        it("npm-run-all command (-h)", async () => {
-            const buf = new BufferStream()
-            await runAll(["-h"], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("run-s command (-h)", async () => {
-            const buf = new BufferStream()
-            await runSeq(["-h"], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("run-p command (-h)", async () => {
-            const buf = new BufferStream()
-            await runPar(["-h"], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("npm-run-all command (--help)", async () => {
-            const buf = new BufferStream()
-            await runAll(["--help"], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("run-s command (--help)", async () => {
-            const buf = new BufferStream()
-            await runSeq(["--help"], buf)
-            assert(/Usage:/.test(buf.value))
-        })
-
-        it("run-p command (--help)", async () => {
-            const buf = new BufferStream()
-            await runPar(["--help"], buf)
-            assert(/Usage:/.test(buf.value))
-        })
+    it("run-s command", async () => {
+      const buf = new BufferStream()
+      await runSeq([], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("should print a version number if the first argument is --version (-v)", () => {
-        it("npm-run-all command (-v)", async () => {
-            const buf = new BufferStream()
-            await runAll(["-v"], buf)
-            assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
-        })
+    it("run-p command", async () => {
+      const buf = new BufferStream()
+      await runPar([], buf)
+      assert(/Usage:/.test(buf.value))
+    })
+  })
 
-        it("run-s command (-v)", async () => {
-            const buf = new BufferStream()
-            await runSeq(["-v"], buf)
-            assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
-        })
-
-        it("run-p command (-v)", async () => {
-            const buf = new BufferStream()
-            await runPar(["-v"], buf)
-            assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
-        })
-
-        it("npm-run-all command (--version)", async () => {
-            const buf = new BufferStream()
-            await runAll(["--version"], buf)
-            assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
-        })
-
-        it("run-s command (--version)", async () => {
-            const buf = new BufferStream()
-            await runSeq(["--version"], buf)
-            assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
-        })
-
-        it("run-p command (--version)", async () => {
-            const buf = new BufferStream()
-            await runPar(["--version"], buf)
-            assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
-        })
+  describe("should print a help text if the first argument is --help (-h)", () => {
+    it("npm-run-all command (-h)", async () => {
+      const buf = new BufferStream()
+      await runAll(["-h"], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("should do nothing if a task list is empty.", () => {
-        it("Node API", async () => {
-            await nodeApi(null)
-            assert(result() == null)
-        })
+    it("run-s command (-h)", async () => {
+      const buf = new BufferStream()
+      await runSeq(["-h"], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("should run a task by npm (check an environment variable):", () => {
-        it("Node API", async () => {
-            await nodeApi("test-task:package-config")
-            assert(result() === "OK")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config"])
-            assert(result() === "OK")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config"])
-            assert(result() === "OK")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config"])
-            assert(result() === "OK")
-        })
+    it("run-p command (-h)", async () => {
+      const buf = new BufferStream()
+      await runPar(["-h"], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("stdin can be used in tasks:", () => {
-        it("Node API", async () => {
-            await nodeApi("test-task:stdin")
-            assert(result().trim() === "STDIN")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:stdin"])
-            assert(result().trim() === "STDIN")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:stdin"])
-            assert(result().trim() === "STDIN")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:stdin"])
-            assert(result().trim() === "STDIN")
-        })
+    it("npm-run-all command (--help)", async () => {
+      const buf = new BufferStream()
+      await runAll(["--help"], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("stdout can be used in tasks:", () => {
-        it("Node API", async () => {
-            await nodeApi("test-task:stdout")
-            assert(result() === "STDOUT")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:stdout"])
-            assert(result() === "STDOUT")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:stdout"])
-            assert(result() === "STDOUT")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:stdout"])
-            assert(result() === "STDOUT")
-        })
+    it("run-s command (--help)", async () => {
+      const buf = new BufferStream()
+      await runSeq(["--help"], buf)
+      assert(/Usage:/.test(buf.value))
     })
 
-    describe("stderr can be used in tasks:", () => {
-        it("Node API", async () => {
-            await nodeApi("test-task:stderr")
-            assert(result() === "STDERR")
-        })
+    it("run-p command (--help)", async () => {
+      const buf = new BufferStream()
+      await runPar(["--help"], buf)
+      assert(/Usage:/.test(buf.value))
+    })
+  })
 
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:stderr"])
-            assert(result() === "STDERR")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:stderr"])
-            assert(result() === "STDERR")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:stderr"])
-            assert(result() === "STDERR")
-        })
+  describe("should print a version number if the first argument is --version (-v)", () => {
+    it("npm-run-all command (-v)", async () => {
+      const buf = new BufferStream()
+      await runAll(["-v"], buf)
+      assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
     })
 
-    describe("should be able to use `restart` built-in task:", () => {
-        it("Node API", () => nodeApi("restart"))
-        it("npm-run-all command", () => runAll(["restart"]))
-        it("run-s command", () => runSeq(["restart"]))
-        it("run-p command", () => runPar(["restart"]))
+    it("run-s command (-v)", async () => {
+      const buf = new BufferStream()
+      await runSeq(["-v"], buf)
+      assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
     })
 
-    describe("should be able to use `env` built-in task:", () => {
-        it("Node API", () => nodeApi("env"))
-        it("npm-run-all command", () => runAll(["env"]))
-        it("run-s command", () => runSeq(["env"]))
-        it("run-p command", () => runPar(["env"]))
+    it("run-p command (-v)", async () => {
+      const buf = new BufferStream()
+      await runPar(["-v"], buf)
+      assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
     })
 
-    if (process.platform === "win32") {
-        describe("issue14", () => {
-            it("Node API", () => nodeApi("test-task:issue14:win32"))
-            it("npm-run-all command", () => runAll(["test-task:issue14:win32"]))
-            it("run-s command", () => runSeq(["test-task:issue14:win32"]))
-            it("run-p command", () => runPar(["test-task:issue14:win32"]))
-        })
+    it("npm-run-all command (--version)", async () => {
+      const buf = new BufferStream()
+      await runAll(["--version"], buf)
+      assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
+    })
+
+    it("run-s command (--version)", async () => {
+      const buf = new BufferStream()
+      await runSeq(["--version"], buf)
+      assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
+    })
+
+    it("run-p command (--version)", async () => {
+      const buf = new BufferStream()
+      await runPar(["--version"], buf)
+      assert(/v[0-9]+\.[0-9]+\.[0-9]+/.test(buf.value))
+    })
+  })
+
+  describe("should do nothing if a task list is empty.", () => {
+    it("Node API", async () => {
+      await nodeApi(null)
+      assert(result() == null)
+    })
+  })
+
+  describe("should run a task by npm (check an environment variable):", () => {
+    it("Node API", async () => {
+      await nodeApi("test-task:package-config")
+      assert(result() === "OK")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:package-config"])
+      assert(result() === "OK")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:package-config"])
+      assert(result() === "OK")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:package-config"])
+      assert(result() === "OK")
+    })
+  })
+
+  describe("stdin can be used in tasks:", () => {
+    it("Node API", async () => {
+      await nodeApi("test-task:stdin")
+      assert(result().trim() === "STDIN")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:stdin"])
+      assert(result().trim() === "STDIN")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:stdin"])
+      assert(result().trim() === "STDIN")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:stdin"])
+      assert(result().trim() === "STDIN")
+    })
+  })
+
+  describe("stdout can be used in tasks:", () => {
+    it("Node API", async () => {
+      await nodeApi("test-task:stdout")
+      assert(result() === "STDOUT")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:stdout"])
+      assert(result() === "STDOUT")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:stdout"])
+      assert(result() === "STDOUT")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:stdout"])
+      assert(result() === "STDOUT")
+    })
+  })
+
+  describe("stderr can be used in tasks:", () => {
+    it("Node API", async () => {
+      await nodeApi("test-task:stderr")
+      assert(result() === "STDERR")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:stderr"])
+      assert(result() === "STDERR")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:stderr"])
+      assert(result() === "STDERR")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:stderr"])
+      assert(result() === "STDERR")
+    })
+  })
+
+  describe("should be able to use `restart` built-in task:", () => {
+    it("Node API", () => nodeApi("restart"))
+    it("npm-run-all command", () => runAll(["restart"]))
+    it("run-s command", () => runSeq(["restart"]))
+    it("run-p command", () => runPar(["restart"]))
+  })
+
+  describe("should be able to use `env` built-in task:", () => {
+    it("Node API", () => nodeApi("env"))
+    it("npm-run-all command", () => runAll(["env"]))
+    it("run-s command", () => runSeq(["env"]))
+    it("run-p command", () => runPar(["env"]))
+  })
+
+  if (process.platform === "win32") {
+    describe("issue14", () => {
+      it("Node API", () => nodeApi("test-task:issue14:win32"))
+      it("npm-run-all command", () => runAll(["test-task:issue14:win32"]))
+      it("run-s command", () => runSeq(["test-task:issue14:win32"]))
+      it("run-p command", () => runPar(["test-task:issue14:win32"]))
+    })
+  } else {
+    describe("issue14", () => {
+      it("Node API", () => nodeApi("test-task:issue14:posix"))
+      it("npm-run-all command", () => runAll(["test-task:issue14:posix"]))
+      it("run-s command", () => runSeq(["test-task:issue14:posix"]))
+      it("run-p command", () => runPar(["test-task:issue14:posix"]))
+    })
+  }
+
+  describe("should not print log if silent option was given:", () => {
+    it("Node API", async () => {
+      const stdout = new BufferStream()
+      const stderr = new BufferStream()
+      try {
+        await nodeApi("test-task:error", { silent: true, stdout, stderr })
+      } catch (_err) {
+        assert(stdout.value === "" && stderr.value === "")
+        return
+      }
+      assert(false, "Should fail.")
+    })
+
+    /**
+     * Strip unknown istanbul's warnings.
+     * @param {string} str - The string to be stripped.
+     * @returns {string} The stripped string.
+     */
+    function stripIstanbulWarnings(str) {
+      return str.replace(/File \[.+?] ignored, nothing could be mapped\r?\n/, "")
     }
-    else {
-        describe("issue14", () => {
-            it("Node API", () => nodeApi("test-task:issue14:posix"))
-            it("npm-run-all command", () => runAll(["test-task:issue14:posix"]))
-            it("run-s command", () => runSeq(["test-task:issue14:posix"]))
-            it("run-p command", () => runPar(["test-task:issue14:posix"]))
-        })
-    }
 
-    describe("should not print log if silent option was given:", () => {
-        it("Node API", async () => {
-            const stdout = new BufferStream()
-            const stderr = new BufferStream()
-            try {
-                await nodeApi("test-task:error", { silent: true, stdout, stderr })
-            }
-            catch (_err) {
-                assert(stdout.value === "" && stderr.value === "")
-                return
-            }
-            assert(false, "Should fail.")
-        })
-
-        /**
-         * Strip unknown istanbul's warnings.
-         * @param {string} str - The string to be stripped.
-         * @returns {string} The stripped string.
-         */
-        function stripIstanbulWarnings(str) {
-            return str.replace(/File \[.+?] ignored, nothing could be mapped\r?\n/, "")
-        }
-
-        it("npm-run-all command", async () => {
-            const stdout = new BufferStream()
-            const stderr = new BufferStream()
-            try {
-                await runAll(["--silent", "test-task:error"], stdout, stderr)
-            }
-            catch (_err) {
-                assert(stdout.value === "" && stripIstanbulWarnings(stderr.value) === "")
-                return
-            }
-            assert(false, "Should fail.")
-        })
-
-        it("run-s command", async () => {
-            const stdout = new BufferStream()
-            const stderr = new BufferStream()
-            try {
-                await runSeq(["--silent", "test-task:error"], stdout, stderr)
-            }
-            catch (_err) {
-                assert(stdout.value === "" && stripIstanbulWarnings(stderr.value) === "")
-                return
-            }
-            assert(false, "Should fail.")
-        })
-
-        it("run-p command", async () => {
-            const stdout = new BufferStream()
-            const stderr = new BufferStream()
-            try {
-                await runPar(["--silent", "test-task:error"], stdout, stderr)
-            }
-            catch (_err) {
-                assert(stdout.value === "" && stripIstanbulWarnings(stderr.value) === "")
-                return
-            }
-            assert(false, "Should fail.")
-        })
+    it("npm-run-all command", async () => {
+      const stdout = new BufferStream()
+      const stderr = new BufferStream()
+      try {
+        await runAll(["--silent", "test-task:error"], stdout, stderr)
+      } catch (_err) {
+        assert(stdout.value === "" && stripIstanbulWarnings(stderr.value) === "")
+        return
+      }
+      assert(false, "Should fail.")
     })
 
-    // https://github.com/mysticatea/npm-run-all/issues/105
-    describe("should not print MaxListenersExceededWarning when it runs 10 tasks:", () => {
-        const tasks = Array.from({ length: 10 }, () => "test-task:append:a")
-
-        it("npm-run-all command", async () => {
-            const buf = new BufferStream()
-            await runAll(tasks, null, buf)
-            assert(buf.value.indexOf("MaxListenersExceededWarning") === -1)
-        })
-
-        it("run-s command", async () => {
-            const buf = new BufferStream()
-            await runSeq(tasks, null, buf)
-            assert(buf.value.indexOf("MaxListenersExceededWarning") === -1)
-        })
-
-        it("run-p command", async () => {
-            const buf = new BufferStream()
-            await runPar(tasks, null, buf)
-            assert(buf.value.indexOf("MaxListenersExceededWarning") === -1)
-        })
+    it("run-s command", async () => {
+      const stdout = new BufferStream()
+      const stderr = new BufferStream()
+      try {
+        await runSeq(["--silent", "test-task:error"], stdout, stderr)
+      } catch (_err) {
+        assert(stdout.value === "" && stripIstanbulWarnings(stderr.value) === "")
+        return
+      }
+      assert(false, "Should fail.")
     })
+
+    it("run-p command", async () => {
+      const stdout = new BufferStream()
+      const stderr = new BufferStream()
+      try {
+        await runPar(["--silent", "test-task:error"], stdout, stderr)
+      } catch (_err) {
+        assert(stdout.value === "" && stripIstanbulWarnings(stderr.value) === "")
+        return
+      }
+      assert(false, "Should fail.")
+    })
+  })
+
+  // https://github.com/mysticatea/npm-run-all/issues/105
+  describe("should not print MaxListenersExceededWarning when it runs 10 tasks:", () => {
+    const tasks = Array.from({ length: 10 }, () => "test-task:append:a")
+
+    it("npm-run-all command", async () => {
+      const buf = new BufferStream()
+      await runAll(tasks, null, buf)
+      assert(buf.value.indexOf("MaxListenersExceededWarning") === -1)
+    })
+
+    it("run-s command", async () => {
+      const buf = new BufferStream()
+      await runSeq(tasks, null, buf)
+      assert(buf.value.indexOf("MaxListenersExceededWarning") === -1)
+    })
+
+    it("run-p command", async () => {
+      const buf = new BufferStream()
+      await runPar(tasks, null, buf)
+      assert(buf.value.indexOf("MaxListenersExceededWarning") === -1)
+    })
+  })
 })

--- a/test/config.js
+++ b/test/config.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const util = require("./lib/util")
 const result = util.result
@@ -23,69 +23,69 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[config] it should have an ability to set config variables:", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
+  beforeEach(removeResult)
 
-    it("Node API should address \"config\" option", async () => {
-        await nodeApi("test-task:config", { config: { test: "this is a config" } })
-        assert(result() === "this is a config")
+  it('Node API should address "config" option', async () => {
+    await nodeApi("test-task:config", { config: { test: "this is a config" } })
+    assert(result() === "this is a config")
+  })
+
+  it('Node API should address "config" option for multiple variables', async () => {
+    await nodeApi("test-task:config2", { config: { test: "1", test2: "2", test3: "3" } })
+    assert(result() === "1\n2\n3")
+  })
+
+  describe('CLI commands should address "--a=b" style options', () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:config", "--test=GO"])
+      assert(result() === "GO")
     })
 
-    it("Node API should address \"config\" option for multiple variables", async () => {
-        await nodeApi("test-task:config2", { config: { test: "1", test2: "2", test3: "3" } })
-        assert(result() === "1\n2\n3")
+    it("run-s command", async () => {
+      await runSeq(["test-task:config", "--test=GO"])
+      assert(result() === "GO")
     })
 
-    describe("CLI commands should address \"--a=b\" style options", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:config", "--test=GO"])
-            assert(result() === "GO")
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:config", "--test=GO"])
+      assert(result() === "GO")
+    })
+  })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:config", "--test=GO"])
-            assert(result() === "GO")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:config", "--test=GO"])
-            assert(result() === "GO")
-        })
+  describe('CLI commands should address "--b=c" style options for multiple variables', () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:config2", "--test=1", "--test2=2", "--test3=3"])
+      assert(result() === "1\n2\n3")
     })
 
-    describe("CLI commands should address \"--b=c\" style options for multiple variables", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:config2", "--test=1", "--test2=2", "--test3=3"])
-            assert(result() === "1\n2\n3")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:config2", "--test=1", "--test2=2", "--test3=3"])
-            assert(result() === "1\n2\n3")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:config2", "--test=1", "--test2=2", "--test3=3"])
-            assert(result() === "1\n2\n3")
-        })
+    it("run-s command", async () => {
+      await runSeq(["test-task:config2", "--test=1", "--test2=2", "--test3=3"])
+      assert(result() === "1\n2\n3")
     })
 
-    describe("CLI commands should transfar configs to nested commands.", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:nested-config", "--test=GO DEEP"])
-            assert(result() === "GO DEEP")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:nested-config", "--test=GO DEEP"])
-            assert(result() === "GO DEEP")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:nested-config", "--test=GO DEEP"])
-            assert(result() === "GO DEEP")
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:config2", "--test=1", "--test2=2", "--test3=3"])
+      assert(result() === "1\n2\n3")
     })
+  })
+
+  describe("CLI commands should transfar configs to nested commands.", () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:nested-config", "--test=GO DEEP"])
+      assert(result() === "GO DEEP")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:nested-config", "--test=GO DEEP"])
+      assert(result() === "GO DEEP")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:nested-config", "--test=GO DEEP"])
+      assert(result() === "GO DEEP")
+    })
+  })
 })

--- a/test/fail.js
+++ b/test/fail.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const util = require("./lib/util")
 const delay = util.delay
@@ -29,10 +29,10 @@ const runSeq = util.runSeq
  * @returns {Promise} A promise which is checked.
  */
 function shouldFail(p) {
-    return p.then(
-        () => assert(false, "should fail"),
-        () => null // OK!
-    )
+  return p.then(
+    () => assert(false, "should fail"),
+    () => null // OK!
+  )
 }
 
 //------------------------------------------------------------------------------
@@ -40,81 +40,82 @@ function shouldFail(p) {
 //------------------------------------------------------------------------------
 
 describe("[fail] it should fail", () => {
-    before(() => process.chdir("test-workspace"))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
+
+  beforeEach(removeResult)
+  afterEach(() => delay(1000))
+
+  describe("if an invalid option exists.", () => {
+    it("npm-run-all command", () => shouldFail(runAll(["--invalid"])))
+    it("run-s command", () => shouldFail(runSeq(["--parallel"])))
+    it("run-p command", () => shouldFail(runPar(["--sequential"])))
+
+    it("npm-run-all command with --race without --parallel", () => shouldFail(runAll(["--race"])))
+    it("npm-run-all command with --r without --parallel", () => shouldFail(runAll(["--r"])))
+    it("run-s command with --race", () => shouldFail(runSeq(["--race"])))
+    it("run-s command with --r", () => shouldFail(runSeq(["--r"])))
+  })
+
+  describe("if invalid `options.taskList` is given.", () => {
+    it("Node API", () => shouldFail(nodeApi("test-task:append a", { taskList: { invalid: 0 } })))
+  })
+
+  describe("if unknown tasks are given:", () => {
+    it("Node API", () => shouldFail(nodeApi("unknown-task")))
+    it("npm-run-all command", () => shouldFail(runAll(["unknown-task"])))
+    it("run-s command", () => shouldFail(runSeq(["unknown-task"])))
+    it("run-p command", () => shouldFail(runPar(["unknown-task"])))
+  })
+
+  describe("if unknown tasks are given (2):", () => {
+    it("Node API", () => shouldFail(nodeApi(["test-task:append:a", "unknown-task"])))
+    it("npm-run-all command", () => shouldFail(runAll(["test-task:append:a", "unknown-task"])))
+    it("run-s command", () => shouldFail(runSeq(["test-task:append:a", "unknown-task"])))
+    it("run-p command", () => shouldFail(runPar(["test-task:append:a", "unknown-task"])))
+  })
+
+  describe("if package.json is not found:", () => {
+    before(() => process.chdir("no-package-json"))
     after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
-    afterEach(() => delay(1000))
+    it("Node API", () => shouldFail(nodeApi(["test-task:append:a"])))
+    it("npm-run-all command", () => shouldFail(runAll(["test-task:append:a"])))
+    it("run-s command", () => shouldFail(runSeq(["test-task:append:a"])))
+    it("run-p command", () => shouldFail(runPar(["test-task:append:a"])))
+  })
 
-    describe("if an invalid option exists.", () => {
-        it("npm-run-all command", () => shouldFail(runAll(["--invalid"])))
-        it("run-s command", () => shouldFail(runSeq(["--parallel"])))
-        it("run-p command", () => shouldFail(runPar(["--sequential"])))
+  describe("if package.json does not have scripts field:", () => {
+    before(() => process.chdir("no-scripts"))
+    after(() => process.chdir(".."))
 
-        it("npm-run-all command with --race without --parallel", () => shouldFail(runAll(["--race"])))
-        it("npm-run-all command with --r without --parallel", () => shouldFail(runAll(["--r"])))
-        it("run-s command with --race", () => shouldFail(runSeq(["--race"])))
-        it("run-s command with --r", () => shouldFail(runSeq(["--r"])))
-    })
+    it("Node API", () => shouldFail(nodeApi(["test-task:append:a"])))
+    it("npm-run-all command", () => shouldFail(runAll(["test-task:append:a"])))
+    it("run-s command", () => shouldFail(runSeq(["test-task:append:a"])))
+    it("run-p command", () => shouldFail(runPar(["test-task:append:a"])))
+  })
 
-    describe("if invalid `options.taskList` is given.", () => {
-        it("Node API", () => shouldFail(nodeApi("test-task:append a", { taskList: { invalid: 0 } })))
-    })
+  describe("if tasks exited with non-zero code:", () => {
+    it("Node API", () => shouldFail(nodeApi("test-task:error")))
+    it("npm-run-all command", () => shouldFail(runAll(["test-task:error"])))
+    it("run-s command", () => shouldFail(runSeq(["test-task:error"])))
+    it("run-p command", () => shouldFail(runPar(["test-task:error"])))
+  })
 
-    describe("if unknown tasks are given:", () => {
-        it("Node API", () => shouldFail(nodeApi("unknown-task")))
-        it("npm-run-all command", () => shouldFail(runAll(["unknown-task"])))
-        it("run-s command", () => shouldFail(runSeq(["unknown-task"])))
-        it("run-p command", () => shouldFail(runPar(["unknown-task"])))
-    })
-
-    describe("if unknown tasks are given (2):", () => {
-        it("Node API", () => shouldFail(nodeApi(["test-task:append:a", "unknown-task"])))
-        it("npm-run-all command", () => shouldFail(runAll(["test-task:append:a", "unknown-task"])))
-        it("run-s command", () => shouldFail(runSeq(["test-task:append:a", "unknown-task"])))
-        it("run-p command", () => shouldFail(runPar(["test-task:append:a", "unknown-task"])))
-    })
-
-    describe("if package.json is not found:", () => {
-        before(() => process.chdir("no-package-json"))
-        after(() => process.chdir(".."))
-
-        it("Node API", () => shouldFail(nodeApi(["test-task:append:a"])))
-        it("npm-run-all command", () => shouldFail(runAll(["test-task:append:a"])))
-        it("run-s command", () => shouldFail(runSeq(["test-task:append:a"])))
-        it("run-p command", () => shouldFail(runPar(["test-task:append:a"])))
-    })
-
-    describe("if package.json does not have scripts field:", () => {
-        before(() => process.chdir("no-scripts"))
-        after(() => process.chdir(".."))
-
-        it("Node API", () => shouldFail(nodeApi(["test-task:append:a"])))
-        it("npm-run-all command", () => shouldFail(runAll(["test-task:append:a"])))
-        it("run-s command", () => shouldFail(runSeq(["test-task:append:a"])))
-        it("run-p command", () => shouldFail(runPar(["test-task:append:a"])))
-    })
-
-    describe("if tasks exited with non-zero code:", () => {
-        it("Node API", () => shouldFail(nodeApi("test-task:error")))
-        it("npm-run-all command", () => shouldFail(runAll(["test-task:error"])))
-        it("run-s command", () => shouldFail(runSeq(["test-task:error"])))
-        it("run-p command", () => shouldFail(runPar(["test-task:error"])))
-    })
-
-    describe("if tasks exited via a signal:", () => {
-        it("Node API", () => shouldFail(nodeApi("test-task:abort")))
-        it("npm-run-all command", () => shouldFail(runAll(["test-task:abort"])))
-        it("run-s command", () => shouldFail(runSeq(["test-task:abort"])))
-        it("run-p command", () => shouldFail(runPar(["test-task:abort"])))
-        it("with correct exit code", () => nodeApi("test-task:abort").then(() =>
-            assert(false, "should fail")
-        ).catch(err => {
-            // In NodeJS versions > 6, the child process correctly sends back
-            // the signal + code of null. In NodeJS versions <= 6, the child
-            // process does not set the signal, and sets the code to 1.
-            const code = Number(process.version.match(/^v(\d+)/)[1]) > 6 ? 134 : 1
-            assert(err.code === code, "should have correct exit code")
+  describe("if tasks exited via a signal:", () => {
+    it("Node API", () => shouldFail(nodeApi("test-task:abort")))
+    it("npm-run-all command", () => shouldFail(runAll(["test-task:abort"])))
+    it("run-s command", () => shouldFail(runSeq(["test-task:abort"])))
+    it("run-p command", () => shouldFail(runPar(["test-task:abort"])))
+    it("with correct exit code", () =>
+      nodeApi("test-task:abort")
+        .then(() => assert(false, "should fail"))
+        .catch((err) => {
+          // In NodeJS versions > 6, the child process correctly sends back
+          // the signal + code of null. In NodeJS versions <= 6, the child
+          // process does not set the signal, and sets the code to 1.
+          const code = Number(process.version.match(/^v(\d+)/)[1]) > 6 ? 134 : 1
+          assert(err.code === code, "should have correct exit code")
         }))
-    })
+  })
 })

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const util = require("./lib/util")
 const result = util.result
 const removeResult = util.removeResult
@@ -20,44 +20,21 @@ const runAll = util.runAll
 //------------------------------------------------------------------------------
 
 describe("[mixed] npm-run-all", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
+  beforeEach(removeResult)
 
-    it("should run a mix of sequential and parallel tasks (has the default group):", async () => {
-        await runAll([
-            "test-task:append a",
-            "-p", "test-task:append b", "test-task:append c",
-            "-s", "test-task:append d", "test-task:append e",
-        ])
-        assert(
-            result() === "aabcbcddee" ||
-            result() === "aabccbddee" ||
-            result() === "aacbbcddee" ||
-            result() === "aacbcbddee"
-        )
-    })
+  it("should run a mix of sequential and parallel tasks (has the default group):", async () => {
+    await runAll(["test-task:append a", "-p", "test-task:append b", "test-task:append c", "-s", "test-task:append d", "test-task:append e"])
+    assert(result() === "aabcbcddee" || result() === "aabccbddee" || result() === "aacbbcddee" || result() === "aacbcbddee")
+  })
 
-    it("should run a mix of sequential and parallel tasks (doesn't have the default group):", async () => {
-        await runAll([
-            "-p", "test-task:append b", "test-task:append c",
-            "-s", "test-task:append d", "test-task:append e",
-        ])
-        assert(
-            result() === "bcbcddee" ||
-            result() === "bccbddee" ||
-            result() === "cbbcddee" ||
-            result() === "cbcbddee"
-        )
-    })
+  it("should run a mix of sequential and parallel tasks (doesn't have the default group):", async () => {
+    await runAll(["-p", "test-task:append b", "test-task:append c", "-s", "test-task:append d", "test-task:append e"])
+    assert(result() === "bcbcddee" || result() === "bccbddee" || result() === "cbbcddee" || result() === "cbcbddee")
+  })
 
-    it("should not throw errors for --race and --max-parallel options if --parallel exists:", () =>
-        runAll([
-            "test-task:append a",
-            "-p", "test-task:append b", "test-task:append c",
-            "-s", "test-task:append d", "test-task:append e",
-            "-r",
-        ])
-    )
+  it("should not throw errors for --race and --max-parallel options if --parallel exists:", () =>
+    runAll(["test-task:append a", "-p", "test-task:append b", "test-task:append c", "-s", "test-task:append d", "test-task:append e", "-r"]))
 })

--- a/test/package-config.js
+++ b/test/package-config.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const util = require("./lib/util")
 const result = util.result
@@ -23,86 +23,86 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[package-config] it should have an ability to overwrite package's config:", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
+  beforeEach(removeResult)
 
-    it("Node API should address \"packageConfig\" option", async () => {
-        await nodeApi("test-task:package-config", { packageConfig: { "npm-run-all-test": { test: "OVERWRITTEN" } } })
-        assert(result() === "OVERWRITTEN")
+  it('Node API should address "packageConfig" option', async () => {
+    await nodeApi("test-task:package-config", { packageConfig: { "npm-run-all-test": { test: "OVERWRITTEN" } } })
+    assert(result() === "OVERWRITTEN")
+  })
+
+  it('Node API should address "packageConfig" option for multiple variables', async () => {
+    await nodeApi("test-task:package-config2", { packageConfig: { "npm-run-all-test": { test: "1", test2: "2", test3: "3" } } })
+    assert(result() === "1\n2\n3")
+  })
+
+  describe('CLI commands should address "--a:b=c" style options', () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
     })
 
-    it("Node API should address \"packageConfig\" option for multiple variables", async () => {
-        await nodeApi("test-task:package-config2", { packageConfig: { "npm-run-all-test": { test: "1", test2: "2", test3: "3" } } })
-        assert(result() === "1\n2\n3")
+    it("run-s command", async () => {
+      await runSeq(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
     })
 
-    describe("CLI commands should address \"--a:b=c\" style options", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
+    })
+  })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config", "--npm-run-all-test:test=OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
+  describe('CLI commands should address "--a:b=c" style options for multiple variables', () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
+      assert(result() === "1\n2\n3")
     })
 
-    describe("CLI commands should address \"--a:b=c\" style options for multiple variables", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
-            assert(result() === "1\n2\n3")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
-            assert(result() === "1\n2\n3")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
-            assert(result() === "1\n2\n3")
-        })
+    it("run-s command", async () => {
+      await runSeq(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
+      assert(result() === "1\n2\n3")
     })
 
-    describe("CLI commands should address \"--a:b c\" style options", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:package-config2", "--npm-run-all-test:test=1", "--npm-run-all-test:test2=2", "--npm-run-all-test:test3=3"])
+      assert(result() === "1\n2\n3")
+    })
+  })
 
-        it("run-s command", async () => {
-            await runSeq(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
+  describe('CLI commands should address "--a:b c" style options', () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
     })
 
-    describe("CLI commands should transfar overriting nested commands.", () => {
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
-            assert(result() === "OVERWRITTEN")
-        })
+    it("run-s command", async () => {
+      await runSeq(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
     })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
+    })
+  })
+
+  describe("CLI commands should transfar overriting nested commands.", () => {
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:nested-package-config", "--npm-run-all-test:test", "OVERWRITTEN"])
+      assert(result() === "OVERWRITTEN")
+    })
+  })
 })

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const spawnWithKill = require("./lib/spawn-with-kill")
 const util = require("./lib/util")
@@ -24,293 +24,227 @@ const runPar = util.runPar
 //------------------------------------------------------------------------------
 
 describe("[parallel]", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(() => delay(1000).then(removeResult))
+  beforeEach(() => delay(1000).then(removeResult))
 
-    describe("should run tasks on parallel when was given --parallel option:", () => {
-        it("Node API", async () => {
-            const results = await nodeApi(["test-task:append a", "test-task:append b"], { parallel: true })
-            assert(results.length === 2)
-            assert(results[0].name === "test-task:append a")
-            assert(results[0].code === 0)
-            assert(results[1].name === "test-task:append b")
-            assert(results[1].code === 0)
-            assert(
-                result() === "abab" ||
-                        result() === "baba" ||
-                        result() === "abba" ||
-                        result() === "baab")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["--parallel", "test-task:append a", "test-task:append b"])
-            assert(
-                result() === "abab" ||
-                        result() === "baba" ||
-                        result() === "abba" ||
-                        result() === "baab")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:append a", "test-task:append b"])
-            assert(
-                result() === "abab" ||
-                        result() === "baba" ||
-                        result() === "abba" ||
-                        result() === "baab")
-        })
+  describe("should run tasks on parallel when was given --parallel option:", () => {
+    it("Node API", async () => {
+      const results = await nodeApi(["test-task:append a", "test-task:append b"], { parallel: true })
+      assert(results.length === 2)
+      assert(results[0].name === "test-task:append a")
+      assert(results[0].code === 0)
+      assert(results[1].name === "test-task:append b")
+      assert(results[1].code === 0)
+      assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
     })
 
-    describe("should kill all tasks when was given --parallel option if a task exited with a non-zero code:", () => {
-        it("Node API", async () => {
-            try {
-                await nodeApi(["test-task:append2 a", "test-task:error"], { parallel: true })
-            }
-            catch (err) {
-                assert(err.results.length === 2)
-                assert(err.results[0].name === "test-task:append2 a")
-                assert(err.results[0].code === undefined)
-                assert(err.results[1].name === "test-task:error")
-                assert(err.results[1].code === 1)
-                assert(result() == null || result() === "a")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("npm-run-all command", async () => {
-            try {
-                await runAll(["--parallel", "test-task:append2 a", "test-task:error"])
-            }
-            catch (_err) {
-                assert(result() == null || result() === "a")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("run-p command", async () => {
-            try {
-                await runPar(["test-task:append2 a", "test-task:error"])
-            }
-            catch (_err) {
-                assert(result() == null || result() === "a")
-                return
-            }
-            assert(false, "should fail")
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["--parallel", "test-task:append a", "test-task:append b"])
+      assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
     })
 
-    describe("should remove intersected tasks from two or more patterns:", () => {
-        it("Node API", async () => {
-            await nodeApi(["test-task:*:a", "*:append:a"], { parallel: true })
-            assert(result() === "aa")
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:append a", "test-task:append b"])
+      assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
+    })
+  })
 
-        it("npm-run-all command", async () => {
-            await runAll(["--parallel", "test-task:*:a", "*:append:a"])
-            assert(result() === "aa")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:*:a", "*:append:a"])
-            assert(result() === "aa")
-        })
+  describe("should kill all tasks when was given --parallel option if a task exited with a non-zero code:", () => {
+    it("Node API", async () => {
+      try {
+        await nodeApi(["test-task:append2 a", "test-task:error"], { parallel: true })
+      } catch (err) {
+        assert(err.results.length === 2)
+        assert(err.results[0].name === "test-task:append2 a")
+        assert(err.results[0].code === undefined)
+        assert(err.results[1].name === "test-task:error")
+        assert(err.results[1].code === 1)
+        assert(result() == null || result() === "a")
+        return
+      }
+      assert(false, "should fail")
     })
 
-    describe("should not remove duplicate tasks from two or more the same pattern:", () => {
-        it("Node API", async () => {
-            await nodeApi(["test-task:*:a", "test-task:*:a"], { parallel: true })
-            assert(result() === "aaaa")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["--parallel", "test-task:*:a", "test-task:*:a"])
-            assert(result() === "aaaa")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:*:a", "test-task:*:a"])
-            assert(result() === "aaaa")
-        })
+    it("npm-run-all command", async () => {
+      try {
+        await runAll(["--parallel", "test-task:append2 a", "test-task:error"])
+      } catch (_err) {
+        assert(result() == null || result() === "a")
+        return
+      }
+      assert(false, "should fail")
     })
 
-    describe("should kill child processes when it's killed", () => {
-        it("npm-run-all command", async () => {
-            await spawnWithKill(
-                "node",
-                ["../bin/npm-run-all/index.js", "--parallel", "test-task:append2 a"]
-            )
-            assert(result() == null || result() === "a")
-        })
+    it("run-p command", async () => {
+      try {
+        await runPar(["test-task:append2 a", "test-task:error"])
+      } catch (_err) {
+        assert(result() == null || result() === "a")
+        return
+      }
+      assert(false, "should fail")
+    })
+  })
 
-        it("run-p command", async () => {
-            await spawnWithKill(
-                "node",
-                ["../bin/run-p/index.js", "test-task:append2 a"]
-            )
-            assert(result() == null || result() === "a")
-        })
+  describe("should remove intersected tasks from two or more patterns:", () => {
+    it("Node API", async () => {
+      await nodeApi(["test-task:*:a", "*:append:a"], { parallel: true })
+      assert(result() === "aa")
     })
 
-    describe("should continue on error when --continue-on-error option was specified:", () => {
-        it("Node API", async () => {
-            try {
-                await nodeApi(["test-task:append a", "test-task:error", "test-task:append b"], { parallel: true, continueOnError: true })
-            }
-            catch (_err) {
-                assert(
-                    result() === "abab" ||
-                    result() === "baba" ||
-                    result() === "abba" ||
-                    result() === "baab"
-                )
-                return
-            }
-            assert(false, "should fail.")
-        })
-
-        it("npm-run-all command (--continue-on-error)", async () => {
-            try {
-                await runAll(["--continue-on-error", "--parallel", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(
-                    result() === "abab" ||
-                    result() === "baba" ||
-                    result() === "abba" ||
-                    result() === "baab"
-                )
-                return
-            }
-            assert(false, "should fail.")
-        })
-
-        it("npm-run-all command (-c)", async () => {
-            try {
-                await runAll(["-cp", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(
-                    result() === "abab" ||
-                    result() === "baba" ||
-                    result() === "abba" ||
-                    result() === "baab"
-                )
-                return
-            }
-            assert(false, "should fail.")
-        })
-
-        it("run-p command (--continue-on-error)", async () => {
-            try {
-                await runPar(["--continue-on-error", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(
-                    result() === "abab" ||
-                    result() === "baba" ||
-                    result() === "abba" ||
-                    result() === "baab"
-                )
-                return
-            }
-            assert(false, "should fail.")
-        })
-
-        it("run-p command (-c)", async () => {
-            try {
-                await runPar(["-c", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(
-                    result() === "abab" ||
-                    result() === "baba" ||
-                    result() === "abba" ||
-                    result() === "baab"
-                )
-                return
-            }
-            assert(false, "should fail.")
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["--parallel", "test-task:*:a", "*:append:a"])
+      assert(result() === "aa")
     })
 
-    describe("should abort other tasks when a task finished, when --race option was specified:", () => {
-        it("Node API", async () => {
-            await nodeApi(["test-task:append1 a", "test-task:append2 b"], { parallel: true, race: true })
-            await delay(5000)
-            assert(result() === "a" || result() === "ab" || result() === "ba")
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:*:a", "*:append:a"])
+      assert(result() === "aa")
+    })
+  })
 
-        it("npm-run-all command (--race)", async () => {
-            await runAll(["--race", "--parallel", "test-task:append1 a", "test-task:append2 b"])
-            await delay(5000)
-            assert(result() === "a" || result() === "ab" || result() === "ba")
-        })
-
-        it("npm-run-all command (-r)", async () => {
-            await runAll(["-rp", "test-task:append1 a", "test-task:append2 b"])
-            await delay(5000)
-            assert(result() === "a" || result() === "ab" || result() === "ba")
-        })
-
-        it("run-p command (--race)", async () => {
-            await runPar(["--race", "test-task:append1 a", "test-task:append2 b"])
-            await delay(5000)
-            assert(result() === "a" || result() === "ab" || result() === "ba")
-        })
-
-        it("run-p command (-r)", async () => {
-            await runPar(["-r", "test-task:append1 a", "test-task:append2 b"])
-            await delay(5000)
-            assert(result() === "a" || result() === "ab" || result() === "ba")
-        })
-
-        it("run-p command (no -r)", async () => {
-            await runPar(["test-task:append1 a", "test-task:append2 b"])
-            await delay(5000)
-            assert(result() === "abb" || result() === "bab")
-        })
+  describe("should not remove duplicate tasks from two or more the same pattern:", () => {
+    it("Node API", async () => {
+      await nodeApi(["test-task:*:a", "test-task:*:a"], { parallel: true })
+      assert(result() === "aaaa")
     })
 
-    describe("should run tasks in parallel-2 when was given --max-parallel 2 option:", () => {
-        it("Node API", async () => {
-            const results = await nodeApi(["test-task:append a", "test-task:append b", "test-task:append c"], { parallel: true, maxParallel: 2 })
-            assert(results.length === 3)
-            assert(results[0].name === "test-task:append a")
-            assert(results[0].code === 0)
-            assert(results[1].name === "test-task:append b")
-            assert(results[1].code === 0)
-            assert(results[2].name === "test-task:append c")
-            assert(results[2].code === 0)
-            assert(
-                result() === "ababcc" ||
-                result() === "babacc" ||
-                result() === "abbacc" ||
-                result() === "baabcc"
-            )
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["--parallel", "test-task:append a", "test-task:append b", "test-task:append c", "--max-parallel", "2"])
-            assert(
-                result() === "ababcc" ||
-                result() === "babacc" ||
-                result() === "abbacc" ||
-                result() === "baabcc"
-            )
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:append a", "test-task:append b", "test-task:append c", "--max-parallel", "2"])
-            assert(
-                result() === "ababcc" ||
-                result() === "babacc" ||
-                result() === "abbacc" ||
-                result() === "baabcc"
-            )
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["--parallel", "test-task:*:a", "test-task:*:a"])
+      assert(result() === "aaaa")
     })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:*:a", "test-task:*:a"])
+      assert(result() === "aaaa")
+    })
+  })
+
+  describe("should kill child processes when it's killed", () => {
+    it("npm-run-all command", async () => {
+      await spawnWithKill("node", ["../bin/npm-run-all/index.js", "--parallel", "test-task:append2 a"])
+      assert(result() == null || result() === "a")
+    })
+
+    it("run-p command", async () => {
+      await spawnWithKill("node", ["../bin/run-p/index.js", "test-task:append2 a"])
+      assert(result() == null || result() === "a")
+    })
+  })
+
+  describe("should continue on error when --continue-on-error option was specified:", () => {
+    it("Node API", async () => {
+      try {
+        await nodeApi(["test-task:append a", "test-task:error", "test-task:append b"], { parallel: true, continueOnError: true })
+      } catch (_err) {
+        assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
+        return
+      }
+      assert(false, "should fail.")
+    })
+
+    it("npm-run-all command (--continue-on-error)", async () => {
+      try {
+        await runAll(["--continue-on-error", "--parallel", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
+        return
+      }
+      assert(false, "should fail.")
+    })
+
+    it("npm-run-all command (-c)", async () => {
+      try {
+        await runAll(["-cp", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
+        return
+      }
+      assert(false, "should fail.")
+    })
+
+    it("run-p command (--continue-on-error)", async () => {
+      try {
+        await runPar(["--continue-on-error", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
+        return
+      }
+      assert(false, "should fail.")
+    })
+
+    it("run-p command (-c)", async () => {
+      try {
+        await runPar(["-c", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "abab" || result() === "baba" || result() === "abba" || result() === "baab")
+        return
+      }
+      assert(false, "should fail.")
+    })
+  })
+
+  describe("should abort other tasks when a task finished, when --race option was specified:", () => {
+    it("Node API", async () => {
+      await nodeApi(["test-task:append1 a", "test-task:append2 b"], { parallel: true, race: true })
+      await delay(5000)
+      assert(result() === "a" || result() === "ab" || result() === "ba")
+    })
+
+    it("npm-run-all command (--race)", async () => {
+      await runAll(["--race", "--parallel", "test-task:append1 a", "test-task:append2 b"])
+      await delay(5000)
+      assert(result() === "a" || result() === "ab" || result() === "ba")
+    })
+
+    it("npm-run-all command (-r)", async () => {
+      await runAll(["-rp", "test-task:append1 a", "test-task:append2 b"])
+      await delay(5000)
+      assert(result() === "a" || result() === "ab" || result() === "ba")
+    })
+
+    it("run-p command (--race)", async () => {
+      await runPar(["--race", "test-task:append1 a", "test-task:append2 b"])
+      await delay(5000)
+      assert(result() === "a" || result() === "ab" || result() === "ba")
+    })
+
+    it("run-p command (-r)", async () => {
+      await runPar(["-r", "test-task:append1 a", "test-task:append2 b"])
+      await delay(5000)
+      assert(result() === "a" || result() === "ab" || result() === "ba")
+    })
+
+    it("run-p command (no -r)", async () => {
+      await runPar(["test-task:append1 a", "test-task:append2 b"])
+      await delay(5000)
+      assert(result() === "abb" || result() === "bab")
+    })
+  })
+
+  describe("should run tasks in parallel-2 when was given --max-parallel 2 option:", () => {
+    it("Node API", async () => {
+      const results = await nodeApi(["test-task:append a", "test-task:append b", "test-task:append c"], { parallel: true, maxParallel: 2 })
+      assert(results.length === 3)
+      assert(results[0].name === "test-task:append a")
+      assert(results[0].code === 0)
+      assert(results[1].name === "test-task:append b")
+      assert(results[1].code === 0)
+      assert(results[2].name === "test-task:append c")
+      assert(results[2].code === 0)
+      assert(result() === "ababcc" || result() === "babacc" || result() === "abbacc" || result() === "baabcc")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["--parallel", "test-task:append a", "test-task:append b", "test-task:append c", "--max-parallel", "2"])
+      assert(result() === "ababcc" || result() === "babacc" || result() === "abbacc" || result() === "baabcc")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:append a", "test-task:append b", "test-task:append c", "--max-parallel", "2"])
+      assert(result() === "ababcc" || result() === "babacc" || result() === "abbacc" || result() === "baabcc")
+    })
+  })
 })

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const BufferStream = require("./lib/buffer-stream")
 const util = require("./lib/util")
@@ -24,190 +24,172 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[pattern] it should run matched tasks if glob like patterns are given.", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
-    beforeEach(removeResult)
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
+  beforeEach(removeResult)
 
-    describe("\"test-task:append:*\" to \"test-task:append:a\" and \"test-task:append:b\"", () => {
-        it("Node API", async () => {
-            await nodeApi("test-task:append:*")
-            assert(result() === "aabb")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:append:*"])
-            assert(result() === "aabb")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:append:*"])
-            assert(result() === "aabb")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:append:*"])
-            assert(
-                result() === "abab" ||
-                result() === "abba" ||
-                result() === "baba" ||
-                result() === "baab"
-            )
-        })
+  describe('"test-task:append:*" to "test-task:append:a" and "test-task:append:b"', () => {
+    it("Node API", async () => {
+      await nodeApi("test-task:append:*")
+      assert(result() === "aabb")
     })
 
-    describe("\"test-task:append:**:*\" to \"test-task:append:a\", \"test-task:append:a:c\", \"test-task:append:a:d\", and \"test-task:append:b\"", () => {
-        it("Node API", async () => {
-            await nodeApi("test-task:append:**:*")
-            assert(result() === "aaacacadadbb")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:append:**:*"])
-            assert(result() === "aaacacadadbb")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:append:**:*"])
-            assert(result() === "aaacacadadbb")
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:append:*"])
+      assert(result() === "aabb")
     })
 
-    describe("(should ignore duplications) \"test-task:append:b\" \"test-task:append:*\" to \"test-task:append:b\", \"test-task:append:a\"", () => {
-        it("Node API", async () => {
-            await nodeApi(["test-task:append:b", "test-task:append:*"])
-            assert(result() === "bbaa")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:append:b", "test-task:append:*"])
-            assert(result() === "bbaa")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:append:b", "test-task:append:*"])
-            assert(result() === "bbaa")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["test-task:append:b", "test-task:append:*"])
-            assert(
-                result() === "baba" ||
-                result() === "baab" ||
-                result() === "abab" ||
-                result() === "abba"
-            )
-        })
+    it("run-s command", async () => {
+      await runSeq(["test-task:append:*"])
+      assert(result() === "aabb")
     })
 
-    describe("\"a\" should not match to \"test-task:append:a\"", () => {
-        it("Node API", async () => {
-            try {
-                await nodeApi("a")
-                assert(false, "should not match")
-            }
-            catch (err) {
-                assert((/not found/i).test(err.message))
-            }
-        })
+    it("run-p command", async () => {
+      await runPar(["test-task:append:*"])
+      assert(result() === "abab" || result() === "abba" || result() === "baba" || result() === "baab")
+    })
+  })
 
-        it("npm-run-all command", async () => {
-            const stderr = new BufferStream()
-            try {
-                await runAll(["a"], null, stderr)
-                assert(false, "should not match")
-            }
-            catch (_err) {
-                assert((/not found/i).test(stderr.value))
-            }
-        })
-
-        it("run-s command", async () => {
-            const stderr = new BufferStream()
-            try {
-                await runSeq(["a"], null, stderr)
-                assert(false, "should not match")
-            }
-            catch (_err) {
-                assert((/not found/i).test(stderr.value))
-            }
-        })
-
-        it("run-p command", async () => {
-            const stderr = new BufferStream()
-            try {
-                await runPar(["a"], null, stderr)
-                assert(false, "should not match")
-            }
-            catch (_err) {
-                assert((/not found/i).test(stderr.value))
-            }
-        })
+  describe('"test-task:append:**:*" to "test-task:append:a", "test-task:append:a:c", "test-task:append:a:d", and "test-task:append:b"', () => {
+    it("Node API", async () => {
+      await nodeApi("test-task:append:**:*")
+      assert(result() === "aaacacadadbb")
     })
 
-    describe("\"!test-task:**\" should not match to anything", () => {
-        it("Node API", async () => {
-            try {
-                await nodeApi("!test-task:**")
-                assert(false, "should not match")
-            }
-            catch (err) {
-                assert((/not found/i).test(err.message))
-            }
-        })
-
-        it("npm-run-all command", async () => {
-            const stderr = new BufferStream()
-            try {
-                await runAll(["!test-task:**"], null, stderr)
-                assert(false, "should not match")
-            }
-            catch (_err) {
-                assert((/not found/i).test(stderr.value))
-            }
-        })
-
-        it("run-s command", async () => {
-            const stderr = new BufferStream()
-            try {
-                await runSeq(["!test-task:**"], null, stderr)
-                assert(false, "should not match")
-            }
-            catch (_err) {
-                assert((/not found/i).test(stderr.value))
-            }
-        })
-
-        it("run-p command", async () => {
-            const stderr = new BufferStream()
-            try {
-                await runPar(["!test-task:**"], null, stderr)
-                assert(false, "should not match")
-            }
-            catch (_err) {
-                assert((/not found/i).test(stderr.value))
-            }
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:append:**:*"])
+      assert(result() === "aaacacadadbb")
     })
 
-    describe("\"!test\" \"?test\" to \"!test\", \"?test\"", () => {
-        it("Node API", async () => {
-            await nodeApi(["!test", "?test"])
-            assert(result().trim() === "XQ")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["!test", "?test"])
-            assert(result().trim() === "XQ")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["!test", "?test"])
-            assert(result().trim() === "XQ")
-        })
-
-        it("run-p command", async () => {
-            await runPar(["!test", "?test"])
-            assert(result().trim() === "XQ" || result().trim() === "QX")
-        })
+    it("run-s command", async () => {
+      await runSeq(["test-task:append:**:*"])
+      assert(result() === "aaacacadadbb")
     })
+  })
+
+  describe('(should ignore duplications) "test-task:append:b" "test-task:append:*" to "test-task:append:b", "test-task:append:a"', () => {
+    it("Node API", async () => {
+      await nodeApi(["test-task:append:b", "test-task:append:*"])
+      assert(result() === "bbaa")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:append:b", "test-task:append:*"])
+      assert(result() === "bbaa")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:append:b", "test-task:append:*"])
+      assert(result() === "bbaa")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["test-task:append:b", "test-task:append:*"])
+      assert(result() === "baba" || result() === "baab" || result() === "abab" || result() === "abba")
+    })
+  })
+
+  describe('"a" should not match to "test-task:append:a"', () => {
+    it("Node API", async () => {
+      try {
+        await nodeApi("a")
+        assert(false, "should not match")
+      } catch (err) {
+        assert(/not found/i.test(err.message))
+      }
+    })
+
+    it("npm-run-all command", async () => {
+      const stderr = new BufferStream()
+      try {
+        await runAll(["a"], null, stderr)
+        assert(false, "should not match")
+      } catch (_err) {
+        assert(/not found/i.test(stderr.value))
+      }
+    })
+
+    it("run-s command", async () => {
+      const stderr = new BufferStream()
+      try {
+        await runSeq(["a"], null, stderr)
+        assert(false, "should not match")
+      } catch (_err) {
+        assert(/not found/i.test(stderr.value))
+      }
+    })
+
+    it("run-p command", async () => {
+      const stderr = new BufferStream()
+      try {
+        await runPar(["a"], null, stderr)
+        assert(false, "should not match")
+      } catch (_err) {
+        assert(/not found/i.test(stderr.value))
+      }
+    })
+  })
+
+  describe('"!test-task:**" should not match to anything', () => {
+    it("Node API", async () => {
+      try {
+        await nodeApi("!test-task:**")
+        assert(false, "should not match")
+      } catch (err) {
+        assert(/not found/i.test(err.message))
+      }
+    })
+
+    it("npm-run-all command", async () => {
+      const stderr = new BufferStream()
+      try {
+        await runAll(["!test-task:**"], null, stderr)
+        assert(false, "should not match")
+      } catch (_err) {
+        assert(/not found/i.test(stderr.value))
+      }
+    })
+
+    it("run-s command", async () => {
+      const stderr = new BufferStream()
+      try {
+        await runSeq(["!test-task:**"], null, stderr)
+        assert(false, "should not match")
+      } catch (_err) {
+        assert(/not found/i.test(stderr.value))
+      }
+    })
+
+    it("run-p command", async () => {
+      const stderr = new BufferStream()
+      try {
+        await runPar(["!test-task:**"], null, stderr)
+        assert(false, "should not match")
+      } catch (_err) {
+        assert(/not found/i.test(stderr.value))
+      }
+    })
+  })
+
+  describe('"!test" "?test" to "!test", "?test"', () => {
+    it("Node API", async () => {
+      await nodeApi(["!test", "?test"])
+      assert(result().trim() === "XQ")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["!test", "?test"])
+      assert(result().trim() === "XQ")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["!test", "?test"])
+      assert(result().trim() === "XQ")
+    })
+
+    it("run-p command", async () => {
+      await runPar(["!test", "?test"])
+      assert(result().trim() === "XQ" || result().trim() === "QX")
+    })
+  })
 })

--- a/test/print-label.js
+++ b/test/print-label.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const BufferStream = require("./lib/buffer-stream")
 const util = require("./lib/util")
@@ -22,203 +22,181 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[print-label] npm-run-all", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    describe("should print labels at the head of every line:", () => {
-        const EXPECTED_TEXT = [
-            "[test-task:echo abc] abcabc",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] abcabc",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] ",
-            "[test-task:echo abc] abc",
-            "[test-task:echo abc] abcabc",
-            "[test-task:echo abc] ",
-            "[test-task:echo abc] ",
-            "[test-task:echo abc] ",
-            "[test-task:echo abc] abc",
-        ].join("\n")
+  describe("should print labels at the head of every line:", () => {
+    const EXPECTED_TEXT = [
+      "[test-task:echo abc] abcabc",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] abcabc",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] ",
+      "[test-task:echo abc] abc",
+      "[test-task:echo abc] abcabc",
+      "[test-task:echo abc] ",
+      "[test-task:echo abc] ",
+      "[test-task:echo abc] ",
+      "[test-task:echo abc] abc"
+    ].join("\n")
 
-        it("Node API", async () => {
-            const stdout = new BufferStream()
-            await nodeApi("test-task:echo abc", { stdout, silent: true, printLabel: true })
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("npm-run-all command (--print-label)", async () => {
-            const stdout = new BufferStream()
-            await runAll(["test-task:echo abc", "--silent", "--print-label"], stdout)
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("run-s command (--print-label)", async () => {
-            const stdout = new BufferStream()
-            await runSeq(["test-task:echo abc", "--silent", "--print-label"], stdout)
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("run-p command (--print-label)", async () => {
-            const stdout = new BufferStream()
-            await runPar(["test-task:echo abc", "--silent", "--print-label"], stdout)
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("npm-run-all command (-l)", async () => {
-            const stdout = new BufferStream()
-            await runAll(["test-task:echo abc", "--silent", "-l"], stdout)
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("run-s command (-l)", async () => {
-            const stdout = new BufferStream()
-            await runSeq(["test-task:echo abc", "--silent", "-l"], stdout)
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("run-p command (-l)", async () => {
-            const stdout = new BufferStream()
-            await runPar(["test-task:echo abc", "--silent", "-l"], stdout)
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
+    it("Node API", async () => {
+      const stdout = new BufferStream()
+      await nodeApi("test-task:echo abc", { stdout, silent: true, printLabel: true })
+      assert.equal(stdout.value, EXPECTED_TEXT)
     })
 
-    describe("should print all labels with the same width:", () => {
-        const EXPECTED_TEXT = [
-            "[test-task:echo a   ] aa",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] aa",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] ",
-            "[test-task:echo a   ] a",
-            "[test-task:echo a   ] aa",
-            "[test-task:echo a   ] ",
-            "[test-task:echo a   ] ",
-            "[test-task:echo a   ] ",
-            "[test-task:echo a   ] a",
-            "[test-task:echo abcd] abcdabcd",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] abcdabcd",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] ",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo abcd] abcdabcd",
-            "[test-task:echo abcd] ",
-            "[test-task:echo abcd] ",
-            "[test-task:echo abcd] ",
-            "[test-task:echo abcd] abcd",
-            "[test-task:echo ab  ] abab",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] abab",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] ",
-            "[test-task:echo ab  ] ab",
-            "[test-task:echo ab  ] abab",
-            "[test-task:echo ab  ] ",
-            "[test-task:echo ab  ] ",
-            "[test-task:echo ab  ] ",
-            "[test-task:echo ab  ] ab",
-        ].join("\n")
-
-        it("Node API", async () => {
-            const stdout = new BufferStream()
-            await nodeApi(
-                ["test-task:echo a", "test-task:echo abcd", "test-task:echo ab"],
-                { stdout, silent: true, printLabel: true }
-            )
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("npm-run-all command", async () => {
-            const stdout = new BufferStream()
-            await runAll(
-                ["test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--silent", "--print-label"],
-                stdout
-            )
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
-
-        it("run-s command", async () => {
-            const stdout = new BufferStream()
-            await runSeq(
-                ["test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--silent", "--print-label"],
-                stdout
-            )
-            assert.equal(stdout.value, EXPECTED_TEXT)
-        })
+    it("npm-run-all command (--print-label)", async () => {
+      const stdout = new BufferStream()
+      await runAll(["test-task:echo abc", "--silent", "--print-label"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
     })
 
-    describe("should work printing labels in parallel:", () => {
-        const EXPECTED_LINES = [
-            "\n[test-task:echo a   ] ",
-            "\n[test-task:echo a   ] a",
-            "\n[test-task:echo ab  ] ",
-            "\n[test-task:echo ab  ] ab",
-            "\n[test-task:echo abcd] ",
-            "\n[test-task:echo abcd] abcd",
-        ]
-        const UNEXPECTED_PATTERNS = [
-            /aab(cd)?/,
-            /ab(cd)?a\b/,
-            /\n\n/,
-        ]
-
-        it("Node API", async () => {
-            const stdout = new BufferStream()
-            await nodeApi(
-                ["test-task:echo a", "test-task:echo abcd", "test-task:echo ab"],
-                { stdout, parallel: true, printLabel: true }
-            )
-            for (const line of EXPECTED_LINES) {
-                assert(stdout.value.indexOf(line) !== -1)
-            }
-            for (const pattern of UNEXPECTED_PATTERNS) {
-                assert(!pattern.test(stdout.value))
-            }
-        })
-
-        it("npm-run-all command", async () => {
-            const stdout = new BufferStream()
-            await runAll(
-                ["--parallel", "test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--print-label"],
-                stdout
-            )
-            for (const line of EXPECTED_LINES) {
-                assert(stdout.value.indexOf(line) !== -1)
-            }
-            for (const pattern of UNEXPECTED_PATTERNS) {
-                assert(!pattern.test(stdout.value))
-            }
-        })
-
-        it("run-p command", async () => {
-            const stdout = new BufferStream()
-            await runPar(
-                ["test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--print-label"],
-                stdout
-            )
-            for (const line of EXPECTED_LINES) {
-                assert(stdout.value.indexOf(line) !== -1)
-            }
-            for (const pattern of UNEXPECTED_PATTERNS) {
-                assert(!pattern.test(stdout.value))
-            }
-        })
+    it("run-s command (--print-label)", async () => {
+      const stdout = new BufferStream()
+      await runSeq(["test-task:echo abc", "--silent", "--print-label"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
     })
+
+    it("run-p command (--print-label)", async () => {
+      const stdout = new BufferStream()
+      await runPar(["test-task:echo abc", "--silent", "--print-label"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+
+    it("npm-run-all command (-l)", async () => {
+      const stdout = new BufferStream()
+      await runAll(["test-task:echo abc", "--silent", "-l"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+
+    it("run-s command (-l)", async () => {
+      const stdout = new BufferStream()
+      await runSeq(["test-task:echo abc", "--silent", "-l"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+
+    it("run-p command (-l)", async () => {
+      const stdout = new BufferStream()
+      await runPar(["test-task:echo abc", "--silent", "-l"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+  })
+
+  describe("should print all labels with the same width:", () => {
+    const EXPECTED_TEXT = [
+      "[test-task:echo a   ] aa",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] aa",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] ",
+      "[test-task:echo a   ] a",
+      "[test-task:echo a   ] aa",
+      "[test-task:echo a   ] ",
+      "[test-task:echo a   ] ",
+      "[test-task:echo a   ] ",
+      "[test-task:echo a   ] a",
+      "[test-task:echo abcd] abcdabcd",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] abcdabcd",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] ",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo abcd] abcdabcd",
+      "[test-task:echo abcd] ",
+      "[test-task:echo abcd] ",
+      "[test-task:echo abcd] ",
+      "[test-task:echo abcd] abcd",
+      "[test-task:echo ab  ] abab",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] abab",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] ",
+      "[test-task:echo ab  ] ab",
+      "[test-task:echo ab  ] abab",
+      "[test-task:echo ab  ] ",
+      "[test-task:echo ab  ] ",
+      "[test-task:echo ab  ] ",
+      "[test-task:echo ab  ] ab"
+    ].join("\n")
+
+    it("Node API", async () => {
+      const stdout = new BufferStream()
+      await nodeApi(["test-task:echo a", "test-task:echo abcd", "test-task:echo ab"], { stdout, silent: true, printLabel: true })
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+
+    it("npm-run-all command", async () => {
+      const stdout = new BufferStream()
+      await runAll(["test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--silent", "--print-label"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+
+    it("run-s command", async () => {
+      const stdout = new BufferStream()
+      await runSeq(["test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--silent", "--print-label"], stdout)
+      assert.equal(stdout.value, EXPECTED_TEXT)
+    })
+  })
+
+  describe("should work printing labels in parallel:", () => {
+    const EXPECTED_LINES = [
+      "\n[test-task:echo a   ] ",
+      "\n[test-task:echo a   ] a",
+      "\n[test-task:echo ab  ] ",
+      "\n[test-task:echo ab  ] ab",
+      "\n[test-task:echo abcd] ",
+      "\n[test-task:echo abcd] abcd"
+    ]
+    const UNEXPECTED_PATTERNS = [/aab(cd)?/, /ab(cd)?a\b/, /\n\n/]
+
+    it("Node API", async () => {
+      const stdout = new BufferStream()
+      await nodeApi(["test-task:echo a", "test-task:echo abcd", "test-task:echo ab"], { stdout, parallel: true, printLabel: true })
+      for (const line of EXPECTED_LINES) {
+        assert(stdout.value.indexOf(line) !== -1)
+      }
+      for (const pattern of UNEXPECTED_PATTERNS) {
+        assert(!pattern.test(stdout.value))
+      }
+    })
+
+    it("npm-run-all command", async () => {
+      const stdout = new BufferStream()
+      await runAll(["--parallel", "test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--print-label"], stdout)
+      for (const line of EXPECTED_LINES) {
+        assert(stdout.value.indexOf(line) !== -1)
+      }
+      for (const pattern of UNEXPECTED_PATTERNS) {
+        assert(!pattern.test(stdout.value))
+      }
+    })
+
+    it("run-p command", async () => {
+      const stdout = new BufferStream()
+      await runPar(["test-task:echo a", "test-task:echo abcd", "test-task:echo ab", "--print-label"], stdout)
+      for (const line of EXPECTED_LINES) {
+        assert(stdout.value.indexOf(line) !== -1)
+      }
+      for (const pattern of UNEXPECTED_PATTERNS) {
+        assert(!pattern.test(stdout.value))
+      }
+    })
+  })
 })

--- a/test/print-name.js
+++ b/test/print-name.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const createHeader = require("../lib/create-header")
 const readPackageJson = require("../lib/read-package-json")
@@ -24,65 +24,64 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[print-name] npm-run-all", () => {
-    let packageInfo = null
+  let packageInfo = null
 
-    before(() => {
-        process.chdir("test-workspace")
-        return readPackageJson().then(info => {
-            packageInfo = info.packageInfo
-        })
+  before(() => {
+    process.chdir("test-workspace")
+    return readPackageJson().then((info) => {
+      packageInfo = info.packageInfo
     })
-    after(() => process.chdir(".."))
+  })
+  after(() => process.chdir(".."))
 
-    describe("should print names before running tasks:", () => {
-        it("Node API", async () => {
-            const stdout = new BufferStream()
-            await nodeApi("test-task:echo abc", { stdout, silent: true, printName: true })
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
-
-        it("npm-run-all command (--print-name)", async () => {
-            const stdout = new BufferStream()
-            await runAll(["test-task:echo abc", "--silent", "--print-name"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
-
-        it("run-s command (--print-name)", async () => {
-            const stdout = new BufferStream()
-            await runSeq(["test-task:echo abc", "--silent", "--print-name"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
-
-        it("run-p command (--print-name)", async () => {
-            const stdout = new BufferStream()
-            await runPar(["test-task:echo abc", "--silent", "--print-name"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
-
-        it("npm-run-all command (-n)", async () => {
-            const stdout = new BufferStream()
-            await runAll(["test-task:echo abc", "--silent", "-n"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
-
-        it("run-s command (-n)", async () => {
-            const stdout = new BufferStream()
-            await runSeq(["test-task:echo abc", "--silent", "-n"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
-
-        it("run-p command (-n)", async () => {
-            const stdout = new BufferStream()
-            await runPar(["test-task:echo abc", "--silent", "-n"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
-            assert.equal(stdout.value.slice(0, header.length), header)
-        })
+  describe("should print names before running tasks:", () => {
+    it("Node API", async () => {
+      const stdout = new BufferStream()
+      await nodeApi("test-task:echo abc", { stdout, silent: true, printName: true })
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
     })
+
+    it("npm-run-all command (--print-name)", async () => {
+      const stdout = new BufferStream()
+      await runAll(["test-task:echo abc", "--silent", "--print-name"], stdout)
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
+    })
+
+    it("run-s command (--print-name)", async () => {
+      const stdout = new BufferStream()
+      await runSeq(["test-task:echo abc", "--silent", "--print-name"], stdout)
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
+    })
+
+    it("run-p command (--print-name)", async () => {
+      const stdout = new BufferStream()
+      await runPar(["test-task:echo abc", "--silent", "--print-name"], stdout)
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
+    })
+
+    it("npm-run-all command (-n)", async () => {
+      const stdout = new BufferStream()
+      await runAll(["test-task:echo abc", "--silent", "-n"], stdout)
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
+    })
+
+    it("run-s command (-n)", async () => {
+      const stdout = new BufferStream()
+      await runSeq(["test-task:echo abc", "--silent", "-n"], stdout)
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
+    })
+
+    it("run-p command (-n)", async () => {
+      const stdout = new BufferStream()
+      await runPar(["test-task:echo abc", "--silent", "-n"], stdout)
+      const header = createHeader("test-task:echo abc", packageInfo, false)
+      assert.equal(stdout.value.slice(0, header.length), header)
+    })
+  })
 })
-

--- a/test/sequential.js
+++ b/test/sequential.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const assert = require("power-assert")
+const assert = require("assert")
 const nodeApi = require("../lib")
 const spawnWithKill = require("./lib/spawn-with-kill")
 const util = require("./lib/util")
@@ -24,181 +24,167 @@ const runSeq = util.runSeq
 //------------------------------------------------------------------------------
 
 describe("[sequencial] npm-run-all", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(() => delay(1000).then(removeResult))
+  beforeEach(() => delay(1000).then(removeResult))
 
-    describe("should run tasks sequentially:", () => {
-        it("Node API", async () => {
-            const results = await nodeApi(["test-task:append a", "test-task:append b"], { parallel: false })
-            assert(results.length === 2)
-            assert(results[0].name === "test-task:append a")
-            assert(results[0].code === 0)
-            assert(results[1].name === "test-task:append b")
-            assert(results[1].code === 0)
-            assert(result() === "aabb")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:append a", "test-task:append b"])
-            assert(result() === "aabb")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:append a", "test-task:append b"])
-            assert(result() === "aabb")
-        })
+  describe("should run tasks sequentially:", () => {
+    it("Node API", async () => {
+      const results = await nodeApi(["test-task:append a", "test-task:append b"], { parallel: false })
+      assert(results.length === 2)
+      assert(results[0].name === "test-task:append a")
+      assert(results[0].code === 0)
+      assert(results[1].name === "test-task:append b")
+      assert(results[1].code === 0)
+      assert(result() === "aabb")
     })
 
-    describe("should not run subsequent tasks if a task exited with a non-zero code:", () => {
-        it("Node API", async () => {
-            try {
-                await nodeApi(["test-task:append2 a", "test-task:error", "test-task:append2 b"])
-            }
-            catch (err) {
-                assert(err.results.length === 3)
-                assert(err.results[0].name === "test-task:append2 a")
-                assert(err.results[0].code === 0)
-                assert(err.results[1].name === "test-task:error")
-                assert(err.results[1].code === 1)
-                assert(err.results[2].name === "test-task:append2 b")
-                assert(err.results[2].code === undefined)
-                assert(result() === "aa")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("npm-run-all command", async () => {
-            try {
-                await runAll(["test-task:append2 a", "test-task:error", "test-task:append2 b"])
-            }
-            catch (_err) {
-                assert(result() === "aa")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("run-s command", async () => {
-            try {
-                await runSeq(["test-task:append2 a", "test-task:error", "test-task:append2 b"])
-            }
-            catch (_err) {
-                assert(result() === "aa")
-                return
-            }
-            assert(false, "should fail")
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:append a", "test-task:append b"])
+      assert(result() === "aabb")
     })
 
-    describe("should remove intersected tasks from two or more patterns:", () => {
-        it("Node API", async () => {
-            await nodeApi(["test-task:*:a", "*:append:a"], { parallel: false })
-            assert(result() === "aa")
-        })
+    it("run-s command", async () => {
+      await runSeq(["test-task:append a", "test-task:append b"])
+      assert(result() === "aabb")
+    })
+  })
 
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:*:a", "*:append:a"])
-            assert(result() === "aa")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:*:a", "*:append:a"])
-            assert(result() === "aa")
-        })
+  describe("should not run subsequent tasks if a task exited with a non-zero code:", () => {
+    it("Node API", async () => {
+      try {
+        await nodeApi(["test-task:append2 a", "test-task:error", "test-task:append2 b"])
+      } catch (err) {
+        assert(err.results.length === 3)
+        assert(err.results[0].name === "test-task:append2 a")
+        assert(err.results[0].code === 0)
+        assert(err.results[1].name === "test-task:error")
+        assert(err.results[1].code === 1)
+        assert(err.results[2].name === "test-task:append2 b")
+        assert(err.results[2].code === undefined)
+        assert(result() === "aa")
+        return
+      }
+      assert(false, "should fail")
     })
 
-    describe("should not remove duplicate tasks from two or more the same pattern:", () => {
-        it("Node API", async () => {
-            await nodeApi(["test-task:*:a", "test-task:*:a"], { parallel: false })
-            assert(result() === "aaaa")
-        })
-
-        it("npm-run-all command", async () => {
-            await runAll(["test-task:*:a", "test-task:*:a"])
-            assert(result() === "aaaa")
-        })
-
-        it("run-s command", async () => {
-            await runSeq(["test-task:*:a", "test-task:*:a"])
-            assert(result() === "aaaa")
-        })
+    it("npm-run-all command", async () => {
+      try {
+        await runAll(["test-task:append2 a", "test-task:error", "test-task:append2 b"])
+      } catch (_err) {
+        assert(result() === "aa")
+        return
+      }
+      assert(false, "should fail")
     })
 
-    describe("should kill child processes when it's killed", () => {
-        it("npm-run-all command", async () => {
-            await spawnWithKill(
-                "node",
-                ["../bin/npm-run-all.js", "test-task:append2 a"]
-            )
-            assert(result() == null || result() === "a")
-        })
+    it("run-s command", async () => {
+      try {
+        await runSeq(["test-task:append2 a", "test-task:error", "test-task:append2 b"])
+      } catch (_err) {
+        assert(result() === "aa")
+        return
+      }
+      assert(false, "should fail")
+    })
+  })
 
-        it("run-s command", async () => {
-            await spawnWithKill(
-                "node",
-                ["../bin/run-s/index.js", "test-task:append2 a"]
-            )
-            assert(result() == null || result() === "a")
-        })
+  describe("should remove intersected tasks from two or more patterns:", () => {
+    it("Node API", async () => {
+      await nodeApi(["test-task:*:a", "*:append:a"], { parallel: false })
+      assert(result() === "aa")
     })
 
-    describe("should continue on error when --continue-on-error option was specified:", () => {
-        it("Node API", async () => {
-            try {
-                await nodeApi(["test-task:append a", "test-task:error", "test-task:append b"], { continueOnError: true })
-            }
-            catch (_err) {
-                assert(result() === "aabb")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("npm-run-all command (--continue-on-error)", async () => {
-            try {
-                await runAll(["--continue-on-error", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(result() === "aabb")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("run-s command (--continue-on-error)", async () => {
-            try {
-                await runSeq(["--continue-on-error", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(result() === "aabb")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("npm-run-all command (-c)", async () => {
-            try {
-                await runAll(["-c", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(result() === "aabb")
-                return
-            }
-            assert(false, "should fail")
-        })
-
-        it("run-s command (-c)", async () => {
-            try {
-                await runSeq(["-c", "test-task:append a", "test-task:error", "test-task:append b"])
-            }
-            catch (_err) {
-                assert(result() === "aabb")
-                return
-            }
-            assert(false, "should fail")
-        })
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:*:a", "*:append:a"])
+      assert(result() === "aa")
     })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:*:a", "*:append:a"])
+      assert(result() === "aa")
+    })
+  })
+
+  describe("should not remove duplicate tasks from two or more the same pattern:", () => {
+    it("Node API", async () => {
+      await nodeApi(["test-task:*:a", "test-task:*:a"], { parallel: false })
+      assert(result() === "aaaa")
+    })
+
+    it("npm-run-all command", async () => {
+      await runAll(["test-task:*:a", "test-task:*:a"])
+      assert(result() === "aaaa")
+    })
+
+    it("run-s command", async () => {
+      await runSeq(["test-task:*:a", "test-task:*:a"])
+      assert(result() === "aaaa")
+    })
+  })
+
+  describe("should kill child processes when it's killed", () => {
+    it("npm-run-all command", async () => {
+      await spawnWithKill("node", ["../bin/npm-run-all.js", "test-task:append2 a"])
+      assert(result() == null || result() === "a")
+    })
+
+    it("run-s command", async () => {
+      await spawnWithKill("node", ["../bin/run-s/index.js", "test-task:append2 a"])
+      assert(result() == null || result() === "a")
+    })
+  })
+
+  describe("should continue on error when --continue-on-error option was specified:", () => {
+    it("Node API", async () => {
+      try {
+        await nodeApi(["test-task:append a", "test-task:error", "test-task:append b"], { continueOnError: true })
+      } catch (_err) {
+        assert(result() === "aabb")
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("npm-run-all command (--continue-on-error)", async () => {
+      try {
+        await runAll(["--continue-on-error", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "aabb")
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("run-s command (--continue-on-error)", async () => {
+      try {
+        await runSeq(["--continue-on-error", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "aabb")
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("npm-run-all command (-c)", async () => {
+      try {
+        await runAll(["-c", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "aabb")
+        return
+      }
+      assert(false, "should fail")
+    })
+
+    it("run-s command (-c)", async () => {
+      try {
+        await runSeq(["-c", "test-task:append a", "test-task:error", "test-task:append b"])
+      } catch (_err) {
+        assert(result() === "aabb")
+        return
+      }
+      assert(false, "should fail")
+    })
+  })
 })

--- a/test/yarn.js
+++ b/test/yarn.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const spawn = require("cross-spawn")
-const assert = require("power-assert")
+const assert = require("assert")
 const BufferStream = require("./lib/buffer-stream")
 const util = require("./lib/util")
 const result = util.result
@@ -27,20 +27,20 @@ const removeResult = util.removeResult
  * @returns {Promise<void>} The result of child process's stdout.
  */
 function exec(command, args) {
-    return new Promise((resolve, reject) => {
-        const stderr = new BufferStream()
-        const cp = spawn(command, args, { stdio: ["ignore", "ignore", "pipe"] })
+  return new Promise((resolve, reject) => {
+    const stderr = new BufferStream()
+    const cp = spawn(command, args, { stdio: ["ignore", "ignore", "pipe"] })
 
-        cp.stderr.pipe(stderr)
-        cp.on("exit", (exitCode) => {
-            if (exitCode) {
-                reject(new Error(`Exited with ${exitCode}: ${stderr.value}`))
-                return
-            }
-            resolve()
-        })
-        cp.on("error", reject)
+    cp.stderr.pipe(stderr)
+    cp.on("exit", (exitCode) => {
+      if (exitCode) {
+        reject(new Error(`Exited with ${exitCode}: ${stderr.value}`))
+        return
+      }
+      resolve()
     })
+    cp.on("error", reject)
+  })
 }
 
 const nodeVersion = Number(process.versions.node.split(".")[0])
@@ -50,15 +50,15 @@ const nodeVersion = Number(process.versions.node.split(".")[0])
 //------------------------------------------------------------------------------
 
 ;(nodeVersion >= 6 ? describe : xdescribe)("[yarn]", () => {
-    before(() => process.chdir("test-workspace"))
-    after(() => process.chdir(".."))
+  before(() => process.chdir("test-workspace"))
+  after(() => process.chdir(".."))
 
-    beforeEach(removeResult)
+  beforeEach(removeResult)
 
-    describe("'yarn run' command", () => {
-        it("should run 'npm-run-all' in scripts with yarn.", async () => {
-            await exec("yarn", ["run", "test-task:yarn"])
-            assert(result() === "aabb")
-        })
+  describe("'yarn run' command", () => {
+    it("should run 'npm-run-all' in scripts with yarn.", async () => {
+      await exec("yarn", ["run", "test-task:yarn"])
+      assert(result() === "aabb")
     })
+  })
 })


### PR DESCRIPTION
**Description**
This merge request introduces a new --retry option that allows specifying the number of additional attempts for each npm‐script. If a task fails, it will be retried up to the configured count before giving up.

**Motivation**
Transient failures (e.g., network glitches, temporarily unavailable resources) can cause pipelines to break unnecessarily.

Automatic retries improve resilience in CI/CD workflows without requiring external workarounds.

Aligns npm-run-all with other CLI tools and task runners that offer retry capabilities.