### PR TITLE
feat(run-tasks): print pattern header before initial thread table

### DIFF
--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -531,6 +531,11 @@ module.exports = function runTasks(tasks, options) {
     // Schedule all initial tasks.
     while (freeThreads > 0 && queue.length > 0) next()
 
+    // Print the invocation header showing the pattern before the thread table.
+    if (runningTasks.size > 0 && showAggregateTable && options.parallelGroupName && options.stdout) {
+      options.stdout.write(`\n▶  npm-run-all-next --parallel "${options.parallelGroupName}"\n`)
+    }
+
     // Print a single table with the initial state after scheduling the first tasks.
     if (runningTasks.size > 0 && showAggregateTable) {
       printThreadTable(runningTasks, jobs, 'INITIAL', 'Initial thread state', options.stdout)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-run-all-next",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A CLI tool to run multiple npm-scripts in parallel or sequentially, with support for retrying failed tasks.",
   "bin": {
     "run-p": "bin/run-p/index.js",


### PR DESCRIPTION
## Summary

When running in `--parallel` + `--aggregate-table` mode, npm-run-all-next now prints a header line before the INITIAL thread status table showing the pattern that was passed:

```
▶  npm-run-all-next --parallel "test:gateway:!(sequential*|group):**"

=======================================================================================
📊 THREAD STATUS [INITIAL - Task: Initial thread state] - ...
```

## Why

In CI logs, npm prints the **npm script name** being executed (e.g. `test:gateway:!(sequential*|group):**`) but there was no indication of what pattern was actually passed to npm-run-all-next. This made it hard to trace which pattern drove task selection.

## Behavior

- Only printed when **both** `--aggregate-table` and `parallelGroupName` are set (i.e. `--parallel` mode)
- No impact on sequential runs or runs without `--aggregate-table`