### PR TITLE
feat(run-tasks): print full invocation command on startup

### DIFF
--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -528,13 +528,17 @@ module.exports = function runTasks(tasks, options) {
       }
     }
 
+    // Print the full invocation command before any tasks start (only at root level).
+    if (options.stdout && !options.summaryParentInvocationId) {
+      const argv = process.argv.slice(2)
+      if (argv.length > 0) {
+        const cmd = require('path').basename(process.argv[1])
+        options.stdout.write(`\n▶  ${cmd} ${argv.join(' ')}\n\n`)
+      }
+    }
+
     // Schedule all initial tasks.
     while (freeThreads > 0 && queue.length > 0) next()
-
-    // Print the invocation header showing the pattern before the thread table.
-    if (runningTasks.size > 0 && showAggregateTable && options.parallelGroupName && options.stdout) {
-      options.stdout.write(`\n▶  npm-run-all-next --parallel "${options.parallelGroupName}"\n`)
-    }
 
     // Print a single table with the initial state after scheduling the first tasks.
     if (runningTasks.size > 0 && showAggregateTable) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-run-all-next",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "description": "A CLI tool to run multiple npm-scripts in parallel or sequentially, with support for retrying failed tasks.",
   "bin": {
     "run-p": "bin/run-p/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-run-all-next",
-  "version": "1.4.4",
+  "version": "1.4.3",
   "description": "A CLI tool to run multiple npm-scripts in parallel or sequentially, with support for retrying failed tasks.",
   "bin": {
     "run-p": "bin/run-p/index.js",


### PR DESCRIPTION
## Summary

Prints the full CLI invocation (`basename(process.argv[1]) + args`) as the very first output line before any tasks are scheduled.

**Before:**
```
> @kong/kong-api-tests@0.0.1 test:gateway:sequential:kafka
> IS_CUSTOM_WORKSPACE=false TEST_APP=gateway ...
```

**After:**
```
▶  npm-run-all-next --parallel --balancer --print-summary-table --runtime-file ./runtimes/classic/test.json --aggregate-output --aggregate-table --continue-on-error --jobs 10 --retries 1 test:gateway:!(sequential*|group):**

> @kong/kong-api-tests@0.0.1 test:gateway:sequential:kafka
> IS_CUSTOM_WORKSPACE=false TEST_APP=gateway ...
```

## Behavior

- Works for all CLI variants (`npm-run-all-next`, `run-p`, `run-s`)
- Works in both parallel and sequential mode
- Suppressed for child/nested invocations (via `summaryParentInvocationId`)
- Uses `path.basename(process.argv[1])` so in production it shows the command name, not the full path

## Version

Bumped to 1.4.4